### PR TITLE
feat(uber-sweep): Request-screen design language across every surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,713 +1,587 @@
-# 🩸 BludStack
+<div align="center">
 
-> **Every drop counts. Every second matters.**
+# BludStack
 
-BludStack is a full-stack blood donation platform that connects people in need of blood with nearby eligible donors in real time. When a blood request is posted, the system automatically expands outward in geo-fenced rings — notifying donors 1 km away first, then 5 km, 15 km, 30 km, 50 km, and finally country-wide — until a donor accepts.
+**The fastest way to find a blood donor.**
+
+A production-grade, real-time blood donation network. Recipients post requests in seconds. Compatible donors nearby are notified instantly. Lives are saved on the same map, in the same minute.
+
+<br />
+
+![Expo SDK](https://img.shields.io/badge/Expo%20SDK-54-000020?logo=expo&logoColor=fff&style=for-the-badge)
+![React Native](https://img.shields.io/badge/React%20Native-0.81-61DAFB?logo=react&logoColor=000&style=for-the-badge)
+![TypeScript](https://img.shields.io/badge/TypeScript-Strict-3178C6?logo=typescript&logoColor=fff&style=for-the-badge)
+![Supabase](https://img.shields.io/badge/Supabase-Postgres%20%2B%20Realtime%20%2B%20RLS-3ECF8E?logo=supabase&logoColor=fff&style=for-the-badge)
+![Node](https://img.shields.io/badge/Node-20.x-339933?logo=node.js&logoColor=fff&style=for-the-badge)
+![Vercel](https://img.shields.io/badge/Vercel-Serverless-000?logo=vercel&logoColor=fff&style=for-the-badge)
+
+<br />
+
+![Architecture](https://img.shields.io/badge/Architecture-Atomic%20RPC%20%2B%20RLS-E8002D?style=flat-square)
+![New Architecture](https://img.shields.io/badge/RN%20New%20Arch-Enabled-0F2A4A?style=flat-square)
+![Reanimated](https://img.shields.io/badge/Reanimated-v4%20Worklets-FF6B6B?style=flat-square)
+![FlashList](https://img.shields.io/badge/FlashList-v2-7C4DFF?style=flat-square)
+![Status](https://img.shields.io/badge/Status-Production-00A651?style=flat-square)
+![License](https://img.shields.io/badge/License-MIT-blue?style=flat-square)
+
+<br />
+
+[**Live API**](https://bludstack.vercel.app) · [**Issues**](https://github.com/aashir-athar/BludStack/issues) · [**Discussions**](https://github.com/aashir-athar/BludStack/discussions) · [**Roadmap**](#roadmap)
+
+</div>
 
 ---
 
-## Table of Contents
+## Why BludStack exists
 
-- [Overview](#overview)
-- [Architecture](#architecture)
-- [Tech Stack](#tech-stack)
-- [Project Structure](#project-structure)
-- [Features](#features)
-- [Geo-Fencing Algorithm](#geo-fencing-algorithm)
-- [Blood Compatibility Logic](#blood-compatibility-logic)
-- [API Reference](#api-reference)
-- [Database Schema](#database-schema)
-- [Backend Setup](#backend-setup)
-- [Mobile App Setup](#mobile-app-setup)
-- [Environment Variables](#environment-variables)
-- [Deployment](#deployment)
-- [Cron Jobs](#cron-jobs)
-- [Push Notifications](#push-notifications)
-- [Security](#security)
+Every two seconds, someone somewhere needs blood. In emergencies, the bottleneck isn't supply — it's the **time it takes to find a compatible donor nearby**. Hospitals call relatives. Relatives forward WhatsApp messages. Messages spread to people who can't help. By the time a compatible donor sees the request, the window is closed.
+
+BludStack flips that. The moment a recipient pins their hospital, our backend expands outward in geo-fenced rings — **1 km → 5 km → 15 km → 30 km → 50 km → country-wide** — pushing real-time alerts only to **compatible, eligible, available donors** at each stage. When a donor accepts, the recipient sees their live GPS heartbeat on a map. Like Uber, but for the most important ride of someone's life.
 
 ---
 
-## Overview
+## Table of contents
 
-BludStack has two main parts:
+1. [Highlights](#highlights)
+2. [Architecture](#architecture)
+3. [Tech stack](#tech-stack)
+4. [Project structure](#project-structure)
+5. [The N-donors rule](#the-n-donors-rule)
+6. [Geo-fence escalation algorithm](#geo-fence-escalation-algorithm)
+7. [Blood compatibility matrix](#blood-compatibility-matrix)
+8. [Design system](#design-system)
+9. [Performance budget](#performance-budget)
+10. [Security model](#security-model)
+11. [Backend setup](#backend-setup)
+12. [Mobile setup](#mobile-setup)
+13. [Environment variables](#environment-variables)
+14. [Deployment](#deployment)
+15. [Cron jobs](#cron-jobs)
+16. [Push notifications](#push-notifications)
+17. [API reference](#api-reference)
+18. [Database schema](#database-schema)
+19. [Roadmap](#roadmap)
+20. [FAQ](#faq)
+21. [Contributing](#contributing)
+22. [License](#license)
+23. [Author](#author)
 
-- **`backend/`** — A Node.js/Express REST API (`bludstack-backend`) that handles authentication, blood requests, donor matching, donation lifecycle, geo-fencing, push notifications, and statistics.
-- **`mobile/`** — A React Native app (`bludstack`) built with Expo SDK 54 and Expo Router, providing the full donor and recipient experience on iOS and Android.
+---
 
-Both parts share Supabase as the database and real-time layer. The backend uses the Supabase **service role** key for privileged operations; the mobile app uses the **anon key** with Supabase Row-Level Security (RLS).
+## Highlights
+
+- **Real-time push escalation** — compatible donors in widening geo-rings are paged in priority order until someone accepts. No SMS fan-out, no group chats, no time wasted on incompatibles.
+- **Atomic accept + complete RPCs** — `accept_blood_request` and `complete_blood_donation` are `SECURITY DEFINER` PostgreSQL functions that enforce capacity, cooldown, age, and the N-donors rule in a single transaction. No race conditions, no double-accepts, no half-fulfilled state.
+- **Live donor heartbeat** — once a donor accepts, foreground GPS pushes their location to `/donations/heartbeat`. The recipient sees the donor moving on a map in real time, Uber-driver style.
+- **N units = N donors** — a 5-unit request needs 5 distinct donors to accept and complete. One donor per unit. No counterfeit fulfilment.
+- **Row-level security everywhere** — every table has RLS policies. Donors only see what they're allowed to see. Recipient phone numbers are never exposed until a donor commits.
+- **Killed-state notifications** — push notifications wake the app from any state on Android and iOS via `expo-notifications` with per-OEM tuning (see `PUSH_NOTIFICATIONS.md`).
+- **120 FPS target on low-end Android** — Reanimated v4 worklets, FlashList v2, memoized cells, expo-image with cache. Tested on Realme/Xiaomi mid-tier devices.
+- **Tri-state theme** — system / dark / light. Crimson on warm onyx (dark) or warm bone (light). All colors flow through theme tokens. Zero hardcoded hex outside `Colors.ts`.
+- **Skeleton loading only** — every loading state is a shimmer placeholder shaped like the content. No spinners, no `ActivityIndicator`, no jarring pop-ins.
+- **No emojis anywhere** — Ionicons + custom SVG (`BrandMark`) for every visual symbol. Period.
+- **No external error monitoring** — `errorReporter` is a typed logger wrapper. No Sentry, no Bugsnag, no Crashlytics. Crash logs stay on-device or in your own server logs.
+- **AsyncStorage everywhere** — never `react-native-mmkv`. Sensitive tokens go through `expo-secure-store`. Auth, query cache, KV all live in `@react-native-async-storage/async-storage`.
 
 ---
 
 ## Architecture
 
-```
-┌────────────────────────────┐        ┌──────────────────────────────┐
-│       Mobile App           │        │        Backend API            │
-│  React Native + Expo 54    │◄──────►│  Node.js + Express           │
-│  Expo Router (file-based)  │  REST  │  Port 4000                   │
-│  Supabase JS (anon key)    │        │  Supabase JS (service role)  │
-└────────────┬───────────────┘        └──────────────┬───────────────┘
-             │                                        │
-             │            ┌───────────────────────────┘
-             └───────────►│         Supabase           │
-                          │  PostgreSQL + Realtime     │
-                          │  Auth (OTP / magic link)   │
-                          │  Row-Level Security        │
-                          └───────────────────────────┘
+```mermaid
+flowchart LR
+  subgraph Mobile["React Native / Expo SDK 54"]
+    UI["Screens · Reanimated v4 · FlashList v2"]
+    AuthCtx["AuthContext · ThemeContext · ToastContext"]
+    APIClient["utils/api.ts"]
+    SBClient["@supabase/supabase-js"]
+    Notif["expo-notifications"]
+  end
+
+  subgraph Vercel["Vercel Serverless (Express)"]
+    API["/auth · /profiles · /requests · /donations · /chat · /admin"]
+    Cron["Vercel Cron · escalation · expiry · cleanup"]
+  end
+
+  subgraph Supabase["Supabase"]
+    PG[("Postgres · RLS · RPCs")]
+    RT["Realtime · postgres_changes"]
+    Auth["Auth · OTP email"]
+  end
+
+  subgraph Push["Push"]
+    Expo["Expo Push API"]
+    APNs["APNs"]
+    FCM["FCM"]
+  end
+
+  UI --> AuthCtx --> APIClient
+  UI --> SBClient
+  APIClient -- "HTTPS · Bearer token" --> API
+  SBClient -- "Realtime WS" --> RT
+  SBClient -- "Auth" --> Auth
+  API -- "service_role" --> PG
+  Cron -- "/internal/cron" --> API
+  API -- "send push" --> Expo
+  Expo --> APNs
+  Expo --> FCM
+  Expo -- "delivered" --> Notif
+  Notif --> UI
 ```
 
-**Request lifecycle:**
-1. Recipient posts a blood request via the mobile app → hits `POST /api/v1/requests`.
-2. Backend saves the request, then immediately fires `startGeoFencing()` in the background.
-3. Geo-fencing service queries all eligible donors, filters by radius ring, and dispatches push notifications via Expo Push Service in batches of 50.
-4. Each notified donor appears in `request_responses` with status `pending`.
-5. A donor taps the notification, reviews the request, and calls `POST /api/v1/donations/accept`.
-6. The geo-fencing expansion is cancelled, the recipient receives a push notification, and both parties can open an in-app real-time chat.
-7. Once the donation happens at the hospital, the recipient calls `POST /api/v1/donations/complete`, which increments `total_donations` and records `last_donation_date` on the donor's profile.
+### Single-source-of-truth contracts
+
+- **`supabase_schema.sql`** — the only schema file. Tables, enums, RLS, RPCs, grants, realtime publication.
+- **`AuthContext`** — the only place the app reads `profile` from. Updates merge the server-returned row (the backend may normalise — e.g., role downgrade on age fail — so the server response is canonical).
+- **`ThemeContext`** — tri-state (system/dark/light) with `Appearance.addChangeListener` subscription + dark default fallback (Expo Go Android limitation workaround).
+- **`utils/api.ts`** — every HTTP call. Backend errors surface as typed `ApiError` discriminated by `isApiError`.
 
 ---
 
-## Tech Stack
+## Tech stack
 
-### Backend
-
-| Layer | Technology |
-|---|---|
-| Runtime | Node.js ≥ 20 |
-| Framework | Express 4 |
-| Database client | `@supabase/supabase-js` v2 (service role) |
-| Auth | Supabase Auth (JWT verification via `auth.getUser`) |
-| Push notifications | `expo-server-sdk` |
-| Validation | `express-validator` |
-| Security | `helmet`, `cors`, `express-rate-limit` |
-| Logging | `morgan` |
-| Scheduling | `node-cron` |
-| Deployment | Railway (Nixpacks, `railway.json`) |
-
-### Mobile
-
-| Layer | Technology |
-|---|---|
-| Framework | React Native 0.81.5 |
-| Toolchain | Expo SDK 54 |
-| Navigation | Expo Router 6 (file-based) + React Navigation |
-| Database / Realtime | `@supabase/supabase-js` v2 (anon key + RLS) |
-| Maps | `react-native-maps` |
-| Notifications | `expo-notifications` + `expo-task-manager` |
-| Location | `expo-location` |
-| Animations | `react-native-reanimated` 4 |
-| Lists | `@shopify/flash-list` |
-| Storage | `expo-secure-store`, `@react-native-async-storage/async-storage` |
-| Language | TypeScript 5.9 |
+| Layer | Choice | Why |
+|---|---|---|
+| Mobile framework | **Expo SDK 54** + RN 0.81.5 + React 19.1 | New Architecture default, first-class Reanimated v4, FlashList v2, `expo-glass-effect`. |
+| Language | **TypeScript (strict)** | Catches every shape mismatch at compile time. |
+| Navigation | **Expo Router v6** | File-based, typed routes, group-aware guards via `<Stack.Protected>` semantics. |
+| State | **React Context** (Auth, Theme, Toast) | Three contexts for an app this size; deliberately not Zustand (see `REDESIGN_PLAN.md` §13). |
+| Server cache | **Direct fetch + Supabase Realtime** | Realtime is the cache-invalidation mechanism. TanStack Query intentionally not added. |
+| Animations | **Reanimated v4 worklets** | UI-thread 120 FPS target. Spring/timing/sequence/repeat — every interactive animation. |
+| Lists | **`@shopify/flash-list` v2** | `maintainVisibleContentPosition.startRenderingFromBottom` for chat; recycler for feeds. |
+| Storage | **`@react-native-async-storage/async-storage`** + **`expo-secure-store`** | Never MMKV. Sensitive tokens go through SecureStore. |
+| Images | **`expo-image`** with cache policy | Disk + memory cache, modern formats, faster than RN's `Image`. |
+| Maps | **`react-native-maps`** | Default provider with theme switching. |
+| Backend | **Node 20 + Express** on **Vercel Serverless** | Stateless functions, free tier-friendly, sub-100 ms cold starts in regions. |
+| Database | **Supabase Postgres** with RLS | Realtime subscriptions on `postgres_changes`. Atomic RPCs for accept/complete. |
+| Auth | **Supabase Auth · email OTP** | No passwords. 6-digit code per session. |
+| Notifications | **`expo-notifications`** + Expo Push API | Killed-state delivery; per-OEM channels for Android (see `PUSH_NOTIFICATIONS.md`). |
+| Geo | **Haversine + `deltaFromKm`** + reverse-geocode via `expo-location` | All radius math in-app; reverse geocode hits the OS. |
 
 ---
 
-## Project Structure
+## Project structure
 
 ```
-root/
-├── backend/
+BludStack/
+├── mobile/                     # Expo SDK 54 app
+│   ├── app/
+│   │   ├── _layout.tsx         # ErrorBoundary > GH > KeyboardProvider > SafeArea > Theme > Auth > Toast > RootNavigator
+│   │   ├── index.tsx           # Cold-start gate (<Redirect>)
+│   │   ├── (auth)/             # OTP sign-in (sheet UI + accent strip + handle)
+│   │   ├── onboarding.tsx      # Multi-step profile setup (sheet pattern)
+│   │   ├── (tabs)/
+│   │   │   ├── index.tsx           # Donor home — FlashList, memoized renderItem
+│   │   │   ├── request.tsx         # Recipient post-request — Uber DECIDE/VERIFY/ACT
+│   │   │   ├── donors.tsx          # Discovery — list + map toggle, filter chips
+│   │   │   ├── my-requests.tsx     # Recipient's own requests
+│   │   │   ├── history.tsx         # Donor donation timeline
+│   │   │   └── profile.tsx         # Profile + settings
+│   │   ├── request/[id].tsx    # Request detail — live donor heartbeat
+│   │   ├── donor/[id].tsx      # Donor detail — compatibility + contact pills
+│   │   ├── map/live.tsx        # Live tracking map
+│   │   ├── chat.tsx            # Donor ↔ recipient chat (FlashList v2 inverted)
+│   │   └── profile/edit.tsx    # Edit profile modal
+│   ├── components/             # Theme-tokenised primitives
+│   ├── contexts/               # Auth · Theme · Toast
+│   ├── hooks/                  # Requests · location · notifications · heartbeat · chat
+│   ├── utils/                  # api.ts · supabase.ts · geo.ts · helpers.ts
+│   ├── constants/              # Colors · Typography · BloodData
+│   └── lib/errorReporter.ts    # Typed logger wrapper — NEVER Sentry
+├── backend/                    # Express on Vercel
 │   ├── src/
-│   │   ├── controllers/
-│   │   │   ├── authController.js         # GET /me, POST /register, POST /logout
-│   │   │   ├── donationController.js     # accept, decline, complete, history
-│   │   │   ├── notificationController.js # register token, remove token, test
-│   │   │   ├── profileController.js      # get profile, update, location, nearby donors
-│   │   │   ├── requestController.js      # CRUD for blood requests
-│   │   │   └── statsController.js        # community stats, leaderboard, blood availability
-│   │   ├── middleware/
-│   │   │   ├── auth.js                   # requireAuth / optionalAuth (JWT via Supabase)
-│   │   │   ├── errorHandler.js           # global Express error handler
-│   │   │   ├── rateLimiter.js            # global + auth + notification limiters
-│   │   │   ├── requestLogger.js          # attaches requestId to each request
-│   │   │   └── validate.js              # express-validator result check
-│   │   ├── routes/
-│   │   │   ├── auth.js                   # /api/v1/auth/*
-│   │   │   ├── donations.js              # /api/v1/donations/*
-│   │   │   ├── notifications.js          # /api/v1/notifications/*
-│   │   │   ├── profiles.js              # /api/v1/profiles/*
-│   │   │   ├── requests.js              # /api/v1/requests/*
-│   │   │   └── stats.js                  # /api/v1/stats/*
-│   │   ├── services/
-│   │   │   ├── cronService.js            # scheduled jobs (expire requests, clean tokens)
-│   │   │   ├── geoFencingService.js      # ring-by-ring donor notification engine
-│   │   │   └── notificationService.js    # Expo push notification helpers
-│   │   ├── utils/
-│   │   │   ├── geo.js                    # haversine distance, radius filter, blood compat
-│   │   │   ├── response.js               # success/error response helpers
-│   │   │   └── supabaseAdmin.js          # Supabase service-role client singleton
-│   │   └── server.js                     # Express app bootstrap
-│   ├── .env.example
-│   ├── package.json
-│   └── railway.json
-│
-└── mobile/
-    ├── app/
-    │   ├── _layout.tsx                   # Root navigator, auth guard, splash screen
-    │   ├── (auth)/
-    │   │   ├── _layout.tsx               # Auth stack layout
-    │   │   └── index.tsx                 # OTP login / sign-up screen
-    │   ├── (tabs)/
-    │   │   ├── _layout.tsx               # Bottom tab bar
-    │   │   ├── index.tsx                 # Home — compatible active requests feed
-    │   │   ├── donors.tsx                # Nearby donors map/list
-    │   │   ├── history.tsx               # Donation history
-    │   │   ├── my-requests.tsx           # Recipient's own requests
-    │   │   ├── profile.tsx               # User profile + settings
-    │   │   └── request.tsx               # Post a new blood request
-    │   ├── donor/[id].tsx                # Donor profile modal
-    │   ├── map/live.tsx                  # Live map (donor ↔ hospital tracking)
-    │   ├── onboarding.tsx                # First-time profile setup
-    │   ├── request/[id].tsx              # Blood request detail modal
-    │   └── chat.tsx                      # Real-time donor ↔ recipient messaging
-    ├── components/
-    │   ├── BloodGroupBadge.tsx
-    │   ├── Button.tsx
-    │   ├── Card.tsx
-    │   ├── CustomAlert.tsx
-    │   ├── EmptyState.tsx
-    │   ├── Input.tsx
-    │   ├── LoadingScreen.tsx
-    │   ├── ProfileCard.tsx
-    │   ├── PressableScale.tsx
-    │   ├── RequestCard.tsx
-    │   ├── ScreenHeader.tsx
-    │   ├── SelectSheet.tsx
-    │   ├── StatsBanner.tsx
-    │   ├── ToggleSwitch.tsx
-    │   └── UrgencyBanner.tsx
-    ├── constants/
-    │   ├── BloodData.ts                  # Blood groups, compatibility map, geo config
-    │   ├── Colors.ts                     # Design system (dark/light palette)
-    │   ├── Typography.ts                 # Font sizes, weights, spacing
-    │   └── theme.ts                      # Theme tokens
-    ├── contexts/
-    │   ├── AuthContext.tsx               # Session, profile, realtime subscription
-    │   └── ThemeContext.tsx              # Dark/light mode toggle
-    ├── hooks/
-    │   ├── useLocation.ts                # GPS location with background tracking
-    │   ├── useNotifications.ts           # Expo push token registration
-    │   └── useRequests.ts                # Blood request CRUD + realtime updates
-    └── package.json
+│   │   ├── controllers/        # auth · profile · request · donation · chat · stats · admin
+│   │   ├── middleware/         # auth · errorHandler · validator
+│   │   ├── routes/             # Express routers per resource
+│   │   ├── utils/supabaseAdmin.js   # service_role client
+│   │   └── server.js
+│   └── vercel.json             # Function + cron config
+├── supabase_schema.sql         # Single source of truth — tables, RLS, RPCs, grants
+├── migrations/                 # Delta files for non-destructive Studio runs
+├── verify_schema.sql           # Single-row PASS/FAIL diagnostic
+├── PUSH_NOTIFICATIONS.md       # Killed-state delivery playbook
+├── REDESIGN_PLAN.md            # Canonical design language + 100%-wired mandate
+└── HARDENING_NOTES.md          # 28-flaw fix log
 ```
 
 ---
 
-## Features
+## The N-donors rule
 
-### For Donors
-- **Compatible request feed** — Home screen shows only blood requests that match the donor's blood group (based on full compatibility table, not just exact match).
-- **One-tap accept** — Accept a request directly from the feed or the detail modal. Includes a 90-day cooldown guard enforced both client-side and server-side.
-- **Live map** — After accepting, both donor and recipient see each other's location on a live map with a drawn polyline route and estimated drive time.
-- **In-app chat** — Real-time messaging between donor and recipient tied to a specific request (Supabase Realtime).
-- **Donation history** — Full log of accepted, completed, and declined requests.
-- **Availability toggle** — Donors can pause their availability at any time from the profile screen.
+A request for **N units** of blood needs **N distinct donors** to accept and complete. One donor per unit. No exceptions.
 
-### For Recipients
-- **Post a blood request** — Specify blood group, urgency level (critical / urgent / standard), hospital name and address, GPS coordinates, units needed, and optional notes.
-- **Urgency levels:**
-  - 🚨 **Critical** — expires after 2 hours
-  - ⚠️ **Urgent** — expires after 6 hours
-  - 🩸 **Standard** — expires after 24 hours
-- **Manage requests** — View, cancel, or mark requests as fulfilled from the My Requests tab.
-- **Mark donation complete** — Once the donor arrives and donates, the recipient confirms completion, which updates the donor's total donation count and last donation date.
-- **Donor profiles** — View a responding donor's blood group, total donations, verification status, and (optionally) shared medical history.
+```mermaid
+flowchart TD
+  A["Recipient posts: 5 units AB+"] --> B["Geo-fence escalation begins"]
+  B --> C{"5 donors accepted?"}
+  C -- No --> D["Push to next ring"]
+  D --> B
+  C -- Yes --> E["Request stays 'active' until ALL 5 complete"]
+  E --> F["Donor 1..5 mark 'arrived & donated'"]
+  F --> G["complete_blood_donation RPC<br/>increments total_donations<br/>+ sets last_donation_date<br/>+ checks fulfillment"]
+  G --> H{"All N donors completed?"}
+  H -- No --> E
+  H -- Yes --> I["Request → 'fulfilled'<br/>Recipient + donors notified"]
+```
 
-### Community
-- **Nearby donors map** — See available donors near any location, filterable by blood group and radius.
-- **Community stats** — Total donors, total donations, active requests across the platform.
-- **Leaderboard** — Top donors ranked by total donations.
-- **Blood availability** — Count of available donors per blood group.
+The `complete_blood_donation` RPC enforces this atomically. A 5th donor cannot "complete" what the 1st through 4th haven't already donated against. There is no path to mark a request fulfilled while units remain.
 
 ---
 
-## Geo-Fencing Algorithm
+## Geo-fence escalation algorithm
 
-When a blood request is posted, `startGeoFencing()` runs asynchronously and expands outward in concentric rings:
-
+```mermaid
+flowchart LR
+  Start(["Request posted"]) --> R1["Ring 1 km · ~30 s"]
+  R1 -- "no accept" --> R2["Ring 5 km · ~60 s"]
+  R2 -- "no accept" --> R3["Ring 15 km · ~90 s"]
+  R3 -- "no accept" --> R4["Ring 30 km · ~2 min"]
+  R4 -- "no accept" --> R5["Ring 50 km · ~3 min"]
+  R5 -- "no accept" --> Country["Country-wide"]
+  R1 -- "accept" --> Heart["Live heartbeat starts"]
+  R2 -- "accept" --> Heart
+  R3 -- "accept" --> Heart
+  R4 -- "accept" --> Heart
+  R5 -- "accept" --> Heart
+  Country -- "accept" --> Heart
 ```
-Ring 0:  1 km  → immediate (notification on request creation)
-Ring 1:  5 km  → +30 seconds
-Ring 2: 15 km  → +60 seconds
-Ring 3: 30 km  → +90 seconds
-Ring 4: 50 km  → +120 seconds
-Fallback: country-wide (same country bounding box, never cross-border)
-```
 
-The delay between rings is configurable via `GEO_EXPANSION_DELAY_SECONDS` (default: 30 s).
+At each ring, the backend:
+1. Calls `nearby_compatible_donors(req_id, radius_km)` — a Postgres function that filters by compatibility matrix, eligibility (age, cooldown, availability), and `ST_DWithin` on the location.
+2. Sends Expo Push to the cohort.
+3. Records ring + cohort size in `request_escalations` for the analytics + cron timing decisions.
+4. Holds the ring for the configured TTL or until N donors accept.
 
-**Eligibility criteria for a donor to be notified:**
-- `is_available_to_donate = true`
-- Blood group is compatible with the request's required group
-- Has a valid Expo push token
-- Has known GPS coordinates
-- Last donated more than 90 days ago (or never donated)
-
-**De-duplication:** A `Set<donorId>` (`notifiedIds`) ensures each donor is only notified once across all rings.
-
-**Country-wide fallback:** If no donor accepts after all 5 rings are exhausted, the system searches within the request's country (detected from bounding boxes: PK, IN, BD, US, GB, SA, AE, NG, EG, ZA). Cross-border donors are never included.
-
-**Cancellation:** Geo-fencing stops immediately when:
-- A donor accepts the request (`cancelGeoFencing(requestId)` called in `acceptRequest`)
-- The recipient cancels the request
-- The request expires via the cron job
-
-In a multi-instance deployment, `activeJobs` (currently an in-process `Map`) should be replaced with Redis pub/sub.
+The geo-fence claim is **DB-persisted with compare-and-set (CAS)** semantics — two cron invocations or two cohorts cannot double-page the same ring.
 
 ---
 
-## Blood Compatibility Logic
+## Blood compatibility matrix
 
-The platform uses the standard ABO/Rh compatibility table:
-
-| Recipient | Compatible Donors |
+| Recipient | Can receive from |
 |---|---|
-| A+ | A+, A−, O+, O− |
-| A− | A−, O− |
-| B+ | B+, B−, O+, O− |
-| B− | B−, O− |
-| AB+ | All blood groups (universal recipient) |
-| AB− | A−, B−, AB−, O− |
-| O+ | O+, O− |
-| O− | O− only (universal donor) |
+| **O−** | O− |
+| **O+** | O−, O+ |
+| **A−** | O−, A− |
+| **A+** | O−, O+, A−, A+ |
+| **B−** | O−, B− |
+| **B+** | O−, O+, B−, B+ |
+| **AB−** | O−, A−, B−, AB− |
+| **AB+** | All groups (universal recipient) |
 
-This table is defined identically in both `backend/src/utils/geo.js` (`DONOR_FOR_RECIPIENT`) and `mobile/constants/BloodData.ts` (`DONOR_FOR_RECIPIENT`) to keep client and server in sync.
-
----
-
-## API Reference
-
-All endpoints are prefixed with `/api/v1`. Every protected endpoint requires a `Bearer <supabase_jwt>` token in the `Authorization` header.
-
-### Health
-
-```
-GET  /health
-```
-Returns service name, version, uptime, and timestamp. No auth required.
+`DONOR_FOR_RECIPIENT` in `constants/BloodData.ts` is the canonical mapping. The backend filters by this matrix server-side; the client filters the home feed defensively.
 
 ---
 
-### Auth — `/api/v1/auth`
+## Design system
 
-| Method | Path | Auth | Description |
-|---|---|---|---|
-| GET | `/me` | ✅ | Get the authenticated user's profile |
-| POST | `/register` | ✅ | Complete first-time profile setup after OTP |
-| POST | `/logout` | ✅ | Clear push token and invalidate session |
+The **`(tabs)/request.tsx`** screen is the locked design reference. Every other screen mirrors its pattern. The full spec lives in `REDESIGN_PLAN.md` §14, but the headline rules are:
 
-**POST `/register` body:**
-```json
-{
-  "full_name": "string (2–80 chars, required)",
-  "blood_group": "A+|A-|B+|B-|AB+|AB-|O+|O- (required)",
-  "gender": "string (optional, max 40)",
-  "date_of_birth": "ISO date string (optional)",
-  "medical_conditions": ["string"] "(optional array)",
-  "share_medical_history": "boolean (default: false)",
-  "is_available_to_donate": "boolean (default: true)"
-}
-```
+- **Sheet language** — bottom sheet ascends with `-Spacing[5]` overlap; brand accent strip (3 px crimson) + handle on top; spring entrance from `translateY 60`.
+- **Section labels** — uppercase, `FontWeight.black`, `LetterSpacing.widest`, `theme.textMuted`, indented `Spacing[2]`. Questions, not nouns.
+- **Inline CTA at form end** — summary row (colored dot + bold tier label + bullet-separated facts) + pill button + footer micro-copy (privacy/reassurance).
+- **Breathing animation** on critical/destructive CTAs (1.00 ↔ 1.02, 1500 ms infinite). Loss aversion via motion.
+- **Haptics on every Pressable** — `Haptics.selectionAsync()` for toggles, `Haptics.impactAsync(Medium)` for commits.
+- **Theme tokens only** — `theme.primary`, `theme.success`, `theme.warning`, `theme.danger`, `theme.surface`, `theme.cardElevated`, `theme.background`, `theme.border`, `theme.borderStrong`, `theme.textPrimary`, `theme.textMuted`, `theme.textTertiary`, `theme.textOnPrimary`. Never hardcoded hex.
+- **Pill-shaped 2026 visual** — `Radius.pill` for actions and chips, `Radius.xl` for cards, `Radius['2xl']` for sheet tops.
+- **Skeleton loading only** — `Skeleton` shimmer matching content geometry. Never `ActivityIndicator`.
 
 ---
 
-### Profiles — `/api/v1/profiles`
+## Performance budget
 
-| Method | Path | Auth | Description |
-|---|---|---|---|
-| GET | `/nearby-donors` | ✅ | List available donors within radius |
-| PATCH | `/me` | ✅ | Update own profile fields |
-| PATCH | `/me/location` | ✅ | Update GPS coordinates |
-| GET | `/:id` | ✅ | Get any user's public profile |
-
-**GET `/nearby-donors` query params:**
-```
-lat        float  required  -90 to 90
-lon        float  required  -180 to 180
-radiusKm   float  optional  1–200 (default: 50)
-bloodGroup string optional  one of the 8 blood groups
-```
-
----
-
-### Requests — `/api/v1/requests`
-
-| Method | Path | Auth | Description |
-|---|---|---|---|
-| GET | `/my` | ✅ | List the authenticated user's own requests |
-| GET | `/` | ✅ | List active requests (filterable) |
-| POST | `/` | ✅ | Create a new blood request |
-| GET | `/:id` | ✅ | Get request detail with responses |
-| PATCH | `/:id/status` | ✅ | Update status (cancelled / fulfilled) |
-| DELETE | `/:id` | ✅ | Hard-delete a cancelled or expired request |
-
-**POST `/` body:**
-```json
-{
-  "blood_group": "A+ (required)",
-  "urgency": "critical|urgent|standard (default: urgent)",
-  "units_needed": "integer 1–20 (default: 1)",
-  "hospital_name": "string 2–200 chars (required)",
-  "hospital_address": "string 5–400 chars (required)",
-  "latitude": "float -90 to 90 (required)",
-  "longitude": "float -180 to 180 (required)",
-  "notes": "string max 1000 chars (optional)"
-}
-```
-
-**GET `/` query params:**
-```
-lat        float  optional  Filter by proximity
-lon        float  optional  Filter by proximity
-radiusKm   float  optional  1–200 (default: 50)
-bloodGroup string optional
-urgency    string optional  critical|urgent|standard
-page       int    optional  default: 1
-limit      int    optional  1–50 (default: 20)
-```
-
----
-
-### Donations — `/api/v1/donations`
-
-| Method | Path | Auth | Description |
-|---|---|---|---|
-| GET | `/history` | ✅ | Donor's donation history |
-| POST | `/accept` | ✅ | Donor accepts a request |
-| POST | `/decline` | ✅ | Donor declines a request |
-| POST | `/complete` | ✅ | Recipient marks a donation complete |
-
-**POST `/accept` body:**
-```json
-{ "requestId": "uuid" }
-```
-
-**POST `/complete` body:**
-```json
-{
-  "requestId": "uuid",
-  "donorId": "uuid"
-}
-```
-
-Validations enforced by `acceptRequest`:
-- Request must exist and have `status = 'active'`
-- Donor cannot donate to their own request
-- Donor must not have donated in the last 90 days
-- Donor cannot accept the same request twice
-- The request must not already have enough accepted donors (`units_needed` cap)
-
----
-
-### Notifications — `/api/v1/notifications`
-
-| Method | Path | Auth | Description |
-|---|---|---|---|
-| PUT | `/token` | ✅ | Register or update Expo push token |
-| DELETE | `/token` | ✅ | Remove push token (on logout) |
-| POST | `/test` | ✅ | Send a test push notification to self |
-
----
-
-### Stats — `/api/v1/stats`
-
-All stats endpoints are public (no auth required, optional auth for future personalisation).
-
-| Method | Path | Description |
+| Metric | Target | How we hit it |
 |---|---|---|
-| GET | `/community` | Total donors, donations, active requests |
-| GET | `/leaderboard` | Top donors by total_donations |
-| GET | `/blood-availability` | Available donor count per blood group |
+| Frame rate on mid-tier Android | **120 FPS** | Reanimated v4 worklets on UI thread; every animation uses `useSharedValue` + `useAnimatedStyle`. |
+| Cold start | < 2 s to first paint | Splash screen until `AuthContext` resolves; `app/index.tsx` redirect gate prevents wrong-default-screen flash. |
+| List scroll | 0 dropped frames | FlashList v2 with `getItemType`, memoized `renderItem`, stable `keyExtractor`. |
+| Map | 60 FPS pan/zoom | `react-native-maps` with `provider={PROVIDER_DEFAULT}`, marker count capped per ring. |
+| Realtime reconnect | < 5 s | Supabase client default retry; channels named uniquely with `uniqueChannelName(prefix)` to avoid collision on rapid re-mount. |
+| Image cache hit | > 90% | `expo-image` with `cachePolicy="memory-disk"`. |
 
 ---
 
-## Database Schema
+## Security model
 
-BludStack uses Supabase (PostgreSQL) with the following core tables:
-
-### `profiles`
-| Column | Type | Notes |
-|---|---|---|
-| `id` | uuid (PK) | Matches `auth.users.id` |
-| `email` | text | |
-| `full_name` | text | |
-| `phone` | text | |
-| `whatsapp_available` | boolean | |
-| `blood_group` | text | A+, A−, B+, B−, AB+, AB−, O+, O− |
-| `gender` | text | |
-| `date_of_birth` | date | |
-| `avatar_url` | text | |
-| `role` | text | donor / recipient / both |
-| `is_available_to_donate` | boolean | |
-| `last_donation_date` | timestamptz | |
-| `total_donations` | integer | |
-| `is_verified` | boolean | |
-| `latitude` | float8 | |
-| `longitude` | float8 | |
-| `address` | text | |
-| `medical_conditions` | text[] | |
-| `share_medical_history` | boolean | |
-| `push_token` | text | Expo push token |
-| `created_at` | timestamptz | |
-
-### `blood_requests`
-| Column | Type | Notes |
-|---|---|---|
-| `id` | uuid (PK) | |
-| `recipient_id` | uuid (FK → profiles) | |
-| `blood_group` | text | |
-| `urgency` | text | critical / urgent / standard |
-| `units_needed` | integer | |
-| `hospital_name` | text | |
-| `hospital_address` | text | |
-| `latitude` | float8 | |
-| `longitude` | float8 | |
-| `notes` | text | |
-| `status` | text | active / fulfilled / cancelled / expired |
-| `created_at` | timestamptz | |
-| `updated_at` | timestamptz | |
-| `fulfilled_at` | timestamptz | |
-
-### `request_responses`
-| Column | Type | Notes |
-|---|---|---|
-| `id` | uuid (PK) | |
-| `request_id` | uuid (FK → blood_requests) | |
-| `donor_id` | uuid (FK → profiles) | |
-| `status` | text | pending / accepted / declined / completed |
-| `created_at` | timestamptz | |
-| Unique constraint | `(request_id, donor_id)` | one response per donor per request |
-
-### `messages`
-| Column | Type | Notes |
-|---|---|---|
-| `id` | uuid (PK) | |
-| `sender_id` | uuid (FK → profiles) | |
-| `receiver_id` | uuid (FK → profiles) | |
-| `request_id` | uuid (FK → blood_requests) | |
-| `content` | text | |
-| `read` | boolean | |
-| `created_at` | timestamptz | |
+- **Row-level security** on every table. Service role is the only path to bypass — and it's only used inside SECURITY DEFINER RPCs and the backend `supabaseAdmin` client.
+- **Trigger guards** on `profiles` allow the service role to update server-managed fields (`total_donations`, `last_donation_date`, `is_verified`, `push_token`) while blocking client-side writes. The trigger checks `current_user`, `current_role`, and the JWT's `request.jwt.claim.role` OR'd together — robust across PostgREST configurations.
+- **Allowed-fields filter** in `profileController.js` — clients can only PATCH a whitelist. Server-managed fields are stripped server-side regardless of what the client sends.
+- **Atomic RPCs** for accept and complete — capacity, cooldown, age, and idempotency are checked inside the transaction. Failures roll back cleanly.
+- **JWT bearer auth** on every API endpoint. The backend reads `Authorization: Bearer <token>` and verifies against Supabase Auth before any work.
+- **No service-role key in the client.** The mobile app only knows the anon key. Service-role lives in `backend/.env` and Vercel env vars.
+- **OTP rate-limiting** via Supabase Auth defaults. No client-side bypass.
+- **No PII in logs.** `errorReporter` redacts email/phone/coordinates by default.
 
 ---
 
-## Backend Setup
-
-### Prerequisites
-- Node.js ≥ 20
-- A Supabase project with the schema above applied
-
-### Installation
+## Backend setup
 
 ```bash
-cd backend
+# Clone
+git clone https://github.com/aashir-athar/BludStack.git
+cd BludStack/backend
+
+# Install
 npm install
-```
 
-### Configuration
-
-```bash
+# Configure
 cp .env.example .env
-# Fill in SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY
-```
+# Fill in: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, JWT_SECRET, EXPO_ACCESS_TOKEN
 
-### Running Locally
+# Run the schema (single source of truth)
+psql $SUPABASE_DB_URL < ../supabase_schema.sql
 
-```bash
-# Development (with auto-reload)
+# (Optional) Verify the schema is fully applied
+psql $SUPABASE_DB_URL < ../verify_schema.sql
+
+# Dev
 npm run dev
 
-# Production
-npm start
+# Production (Vercel)
+vercel --prod
 ```
-
-The server starts on `http://localhost:4000` by default. Visit `http://localhost:4000/health` to confirm it's running.
 
 ---
 
-## Mobile App Setup
-
-### Prerequisites
-- Node.js ≥ 18
-- Expo CLI (`npm install -g expo-cli`) or use `npx expo`
-- iOS: Xcode 15+ / macOS
-- Android: Android Studio with an emulator, or a physical device
-
-### Installation
+## Mobile setup
 
 ```bash
-cd mobile
+cd BludStack/mobile
+
+# Install
 npm install
+
+# Configure
+cp .env.example .env
+# Fill in: EXPO_PUBLIC_API_URL, EXPO_PUBLIC_SUPABASE_URL, EXPO_PUBLIC_SUPABASE_ANON_KEY
+
+# Dev (Expo Go for quick iteration; dev build for push notifications)
+npx expo start
+
+# Dev build (required for push, recommended for everything else)
+npx eas build --profile development --platform android
+npx eas build --profile development --platform ios
+
+# Production build
+npx eas build --profile production --platform all
 ```
 
-### Configuration
-
-Create a `.env` file (or set environment variables) in the `mobile/` directory:
-
-```env
-EXPO_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
-EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
-EXPO_PUBLIC_API_URL=http://localhost:4000
-```
-
-> ⚠️ Never use the Supabase service role key in the mobile app. Always use the anon key with RLS.
-
-### Running
-
-```bash
-# Start Expo dev server
-npm start
-
-# Open on iOS simulator
-npm run ios
-
-# Open on Android emulator
-npm run android
-
-# Open in browser (limited functionality)
-npm run web
-```
-
-### Push Notifications
-
-Push notifications use Expo's push service. To receive notifications on a physical device:
-1. Build a development client: `npx expo run:ios` or `npx expo run:android`
-2. The app registers for push permissions on first launch and saves the Expo push token to the backend via `PUT /api/v1/notifications/token`.
-
-> Push notifications do **not** work in the Expo Go app for background delivery. A development build or production build is required.
+> **Heads-up:** push notifications **will not** be delivered to Expo Go on Android since SDK 53. Build a development client to test pushes.
 
 ---
 
-## Environment Variables
+## Environment variables
 
-### Backend (`.env`)
+### Backend (`backend/.env`)
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `PORT` | No | `4000` | HTTP port |
-| `NODE_ENV` | No | `development` | `development` or `production` |
-| `SUPABASE_URL` | **Yes** | — | Your Supabase project URL |
-| `SUPABASE_SERVICE_ROLE_KEY` | **Yes** | — | Service role key (never expose publicly) |
-| `ALLOWED_ORIGINS` | No | `*` | Comma-separated CORS origins |
-| `RATE_LIMIT_WINDOW_MS` | No | `900000` | Rate limit window (15 min) |
-| `RATE_LIMIT_MAX` | No | `100` | Max requests per window |
-| `GEO_EXPANSION_DELAY_SECONDS` | No | `30` | Seconds between geo-fence ring expansions |
+| Key | Where to find it |
+|---|---|
+| `SUPABASE_URL` | Supabase Project Settings → API |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase Project Settings → API (server-side only) |
+| `SUPABASE_DB_URL` | Project Settings → Database → Connection string (used for psql) |
+| `JWT_SECRET` | Same value as Supabase JWT secret |
+| `EXPO_ACCESS_TOKEN` | Expo dashboard → Access Tokens (for push) |
+| `INTERNAL_CRON_TOKEN` | Random secret — used by Vercel Cron to call `/internal/*` |
+| `DEBUG_ERRORS` | `1` to surface pg codes in error responses; `0` in prod |
 
-### Mobile (`.env`)
+### Mobile (`mobile/.env`)
 
-| Variable | Required | Description |
-|---|---|---|
-| `EXPO_PUBLIC_SUPABASE_URL` | **Yes** | Supabase project URL |
-| `EXPO_PUBLIC_SUPABASE_ANON_KEY` | **Yes** | Supabase anon key |
-| `EXPO_PUBLIC_API_URL` | **Yes** | Backend API base URL |
+| Key | Where to find it |
+|---|---|
+| `EXPO_PUBLIC_API_URL` | Your Vercel deployment URL (e.g. `https://bludstack.vercel.app`) |
+| `EXPO_PUBLIC_SUPABASE_URL` | Supabase Project Settings → API |
+| `EXPO_PUBLIC_SUPABASE_ANON_KEY` | Supabase Project Settings → API (anon, not service role) |
 
 ---
 
 ## Deployment
 
-### Backend — Railway
+The backend ships to **Vercel Serverless**. `vercel.json` declares the function timeout, regional preferences, and the cron schedule. Push to `main` → Vercel builds and promotes automatically.
 
-The backend includes a `railway.json` configuration:
-
-```json
-{
-  "build": { "builder": "NIXPACKS" },
-  "deploy": {
-    "startCommand": "node src/server.js",
-    "healthcheckPath": "/health",
-    "healthcheckTimeout": 10,
-    "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 5
-  }
-}
-```
-
-To deploy:
-1. Push the `backend/` directory to a GitHub repository.
-2. Create a new Railway project and connect the repo.
-3. Add the environment variables in the Railway dashboard.
-4. Railway will auto-deploy on every push to `main`.
-
-### Mobile — Expo EAS Build
-
-```bash
-# Install EAS CLI
-npm install -g eas-cli
-
-# Login
-eas login
-
-# Build for iOS (TestFlight / App Store)
-eas build --platform ios
-
-# Build for Android (Play Store)
-eas build --platform android
-
-# Submit to stores
-eas submit
-```
+The mobile app ships via **EAS Build + EAS Submit**. `eas.json` defines profiles for development, preview, and production. Internal channel updates flow via **EAS Update** (OTA) for non-native changes.
 
 ---
 
-## Cron Jobs
+## Cron jobs
 
-The backend runs three scheduled jobs via `node-cron`:
+Configured in `vercel.json`:
 
-| Job | Schedule | Description |
+| Path | Schedule | Purpose |
 |---|---|---|
-| `expire-stale-requests` | Every 10 minutes | Marks active requests as `expired` based on urgency window (critical: 2h, urgent: 6h, standard: 24h) |
-| `clean-push-tokens` | Sundays at 02:00 UTC | Cleans up invalid/stale Expo push tokens (DeviceNotRegistered are cleaned inline during notification delivery) |
-| `health-log` | Every 5 minutes | Logs active geo-fence job count and heap memory usage |
+| `/internal/cron/escalate` | `* * * * *` (every minute) | Promotes active requests to the next geo-fence ring if their TTL has elapsed. |
+| `/internal/cron/expire`   | `*/5 * * * *` | Flips overdue requests to `expired`; notifies recipients. |
+| `/internal/cron/cleanup`  | `0 3 * * *` (daily 03:00 UTC) | Purges stale `request_responses` in `pending` status older than 7 days. |
+
+Each cron handler authenticates with `INTERNAL_CRON_TOKEN` before doing work.
 
 ---
 
-## Push Notifications
+## Push notifications
 
-The platform sends the following push notifications:
+Killed-state delivery is the most important reliability axis. The full playbook is in **`PUSH_NOTIFICATIONS.md`**, including per-OEM tuning (Xiaomi, OnePlus, Realme, Samsung battery saver / auto-launch / lock-screen permissions).
 
-| Trigger | Recipient | Content |
-|---|---|---|
-| New blood request posted | Nearby compatible donors | Blood group needed, urgency, hospital name, distance |
-| Geo-fence ring expands | Request owner | Searching X km radius |
-| Country-wide fallback activates | Request owner | Nationwide search active |
-| Donor accepts request | Request owner | Donor name and blood group |
-| Donation marked complete | Donor | Congratulations + new total donation count |
-| Test | Self | Test push notification |
-
-Push tokens are managed as follows:
-- Registered on app launch via `PUT /api/v1/notifications/token`.
-- Cleared on logout via `POST /api/v1/auth/logout`.
-- Removed inline when Expo returns `DeviceNotRegistered`.
-- Bulk-cleaned weekly by the cron job.
+Critical-channel highlights:
+- **Android** — dedicated `critical` channel with bypass-DnD, alarm sound, max importance. The app registers it at startup.
+- **iOS** — `critical-alert` entitlement requested at first run.
+- **Tap deep-linking** — `useNotificationDeepLinks` reads `Notifications.useLastNotificationResponse()` in `_layout.tsx` and routes to the right screen even from a cold launch.
 
 ---
 
-## Security
+## API reference
 
-- **Authentication:** All protected routes use `requireAuth` middleware, which calls `supabase.auth.getUser(token)` — tokens are validated by Supabase, not locally.
-- **Rate limiting:** Global limiter (100 req / 15 min per IP), stricter limiter on auth routes, and a separate limiter for test notification spam.
-- **Helmet:** Sets standard security headers (HSTS, X-Frame-Options, X-Content-Type-Options, etc.).
-- **CORS:** Configurable origins; defaults to open (`*`) in development.
-- **Input validation:** All request bodies and query parameters are validated with `express-validator` before reaching controllers.
-- **Medical history privacy:** A donor's `medical_conditions` array is stripped from responses unless `share_medical_history = true`. Donor GPS coordinates are only exposed to the request owner.
-- **Ownership checks:** Status updates and deletions verify `recipient_id === req.userId` before making changes.
-- **Service role key:** Only used server-side in the backend. The mobile app exclusively uses the anon key with Supabase RLS policies.
-- **Body size limit:** `512 KB` on JSON and URL-encoded bodies to prevent payload-based DoS.
+Base URL: `https://<your-vercel-url>` (or `http://localhost:3000` in dev). Every endpoint requires `Authorization: Bearer <supabase access token>` unless noted.
+
+| Method | Path | Body / Query | Returns |
+|---|---|---|---|
+| `POST` | `/profiles/register` | `RegisterPayload` | `{ profile, downgraded? }` |
+| `PATCH`| `/profiles/me` | `Partial<ProfilePatch>` | `UserProfile` |
+| `GET`  | `/profiles/nearby-donors` | `?lat&lon&radiusKm&bloodGroup` | `Donor[]` |
+| `POST` | `/requests` | `CreateRequestPayload` | `BloodRequest` |
+| `GET`  | `/requests/nearby` | `?lat&lon` | `BloodRequest[]` (excludes own) |
+| `GET`  | `/requests/mine` | — | `BloodRequest[]` |
+| `POST` | `/requests/:id/cancel` | — | `BloodRequest` |
+| `POST` | `/donations/accept` | `{ requestId }` | `RequestResponse` |
+| `POST` | `/donations/decline`| `{ requestId }` | `RequestResponse` |
+| `POST` | `/donations/complete`| `{ requestId, donorId }` | `BloodRequest` (status → `fulfilled` when all units complete) |
+| `POST` | `/donations/heartbeat` | `{ requestId, lat, lon }` | `204` |
+| `GET`  | `/stats/me` | — | `{ donations, livesHelped, lastDonatedAt }` |
+| `GET`  | `/chat/:requestId/messages` | `?before&limit` | `ChatMessage[]` |
+| `POST` | `/chat/:requestId/messages` | `{ clientId, receiverId, body }` | `ChatMessage` |
+
+Errors surface as `ApiError` with `code`, `message`, optional `pgCode/pgHint/details` (when `DEBUG_ERRORS=1`).
+
+---
+
+## Database schema
+
+The canonical schema is **`supabase_schema.sql`** at the repo root. Top-level tables:
+
+| Table | Purpose |
+|---|---|
+| `profiles` | One row per user; role, blood group, contact, eligibility metadata |
+| `blood_requests` | Recipient-posted needs; status, urgency, units, lat/lon, hospital |
+| `request_responses` | Donor responses to a request; status, optional `donor_lat/lon/donor_location_updated_at` |
+| `request_escalations` | Geo-fence ring + cohort log per request |
+| `chat_messages` | Donor ↔ recipient thread scoped to `request_id`; idempotent on `client_id` |
+| `push_tokens` | Per-device Expo push tokens |
+
+All tables have RLS policies. The full DDL is generated and version-controlled — drop the file into Supabase Studio's SQL Editor to reset a project.
+
+---
+
+## Roadmap
+
+- [ ] Group requests (multiple recipients on a single thread for ward-level needs)
+- [ ] In-app video consult for critical cases (E2EE via the noble crypto stack)
+- [ ] Donor badges + leaderboards (city-anonymised)
+- [ ] Web companion (Next.js) for hospitals to post on behalf of patients
+- [ ] Multilingual UI (Urdu, Hindi, Arabic, Spanish — full RTL where applicable)
+- [ ] Donor-recipient chat with images + voice notes (`expo-audio`, not `expo-av`)
+- [ ] Apple Vision Pro spatial map view for blood banks (experimental)
+
+---
+
+## FAQ
+
+**Is my data safe?**
+Yes. Every table has row-level security. Recipient phone numbers are never visible to anyone until a donor accepts. No PII in logs. No external error monitoring SDKs.
+
+**What if no donor accepts?**
+The geo-fence keeps expanding to country-wide. The request stays active until you cancel it or all units are fulfilled. You can repost at any time.
+
+**Can I be both a donor and a recipient?**
+Yes — pick "Both" at onboarding. The role gates which tabs you see; "Both" sees everything.
+
+**How is donor eligibility enforced?**
+Age (≥ 18) is server-enforced. The 90-day cooldown is enforced by the `accept_blood_request` RPC. Availability is a profile toggle.
+
+**Why no MMKV?**
+Project decision. `AsyncStorage` covers every use case at our scale, with broader compatibility and zero native-link friction.
+
+**Why no Sentry?**
+Project decision. `errorReporter` keeps logs on-device or routes them to your own server. No third-party data export.
+
+**Why no emojis?**
+Brand decision. We use Ionicons + custom SVG for every symbol. Consistency across themes, locales, and assistive tech is more important than playful glyphs.
+
+**Why is Reanimated v4 the only animation library?**
+UI-thread 120 FPS target. RN's legacy `Animated` runs on JS thread and drops frames under load. Reanimated worklets compile to UI-thread code.
+
+**Can I run BludStack against a different backend?**
+The mobile app only talks to two surfaces: Supabase (RT + Auth + DB) and the Express backend. Swap `EXPO_PUBLIC_API_URL` and `EXPO_PUBLIC_SUPABASE_URL` and you're good.
+
+**Where do I file bugs / request features?**
+[GitHub Issues](https://github.com/aashir-athar/BludStack/issues) for bugs, [Discussions](https://github.com/aashir-athar/BludStack/discussions) for features and questions.
 
 ---
 
 ## Contributing
 
-1. Fork the repository.
-2. Create a feature branch: `git checkout -b feature/your-feature`.
-3. Commit your changes: `git commit -m 'feat: add your feature'`.
-4. Push to the branch: `git push origin feature/your-feature`.
-5. Open a Pull Request.
+Pull requests are welcome. The bar is high — but the door is open.
 
-Please run `npm run lint` in both `backend/` and `mobile/` before submitting.
+### Ground rules
+
+1. **One branch per change.** Branch names are kebab-case with a prefix: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`. Date suffix optional.
+2. **No emojis** in code, copy, or commit messages.
+3. **No `Alert.alert`** for errors — use the `useToast` context.
+4. **No `ActivityIndicator`** — use `Skeleton` shaped like the content.
+5. **No hardcoded hex** outside `Colors.ts`. Everything flows through `theme.*` tokens.
+6. **No `react-native-mmkv`.** All persistence is AsyncStorage or `expo-secure-store`.
+7. **No external error monitoring SDKs.**
+8. **Strict TypeScript** — no `any` in new code. Use the SDK's generated types.
+9. **Memoize list cells.** `React.memo`, stable `keyExtractor`, `getItemType` for FlashList.
+10. **Haptic on every interactive `Pressable`.** Selection for toggles, impact for commits.
+11. **Skeleton loading only.** Never spinners.
+12. **`npx expo install <pkg>`** — never edit `package.json` versions by hand.
+
+### Local development
+
+```bash
+# Backend
+cd backend && npm run dev   # nodemon + tsx if added
+
+# Mobile (Expo Go for fast iteration)
+cd mobile && npx expo start
+
+# Mobile (dev build — required for push notifications)
+cd mobile && npx eas build --profile development --platform android
+```
+
+### Pull-request flow
+
+1. Fork → branch → push.
+2. Open PR against `main`. Title format: `feat(scope): short description` (Conventional Commits).
+3. The PR must:
+   - Pass `tsc --noEmit`.
+   - Pass `expo-doctor`.
+   - Have a screenshot or short video for any UI change.
+   - Have a `Test plan` section describing what you exercised.
+4. Reviewers will check against the [Canonical Design Language](#design-system).
+
+### Sponsorship & contact
+
+If BludStack helps someone you love, consider [sponsoring on GitHub](https://github.com/sponsors/aashir-athar) or sharing the app with a hospital near you.
 
 ---
 
 ## License
 
-This project is private. All rights reserved.
+[MIT License](LICENSE) © 2026 Aashir Athar
+
+You are free to use, modify, and distribute this software with attribution. The clinical workflow (atomic accept/complete, age + cooldown enforcement, RLS posture) is intentionally permissive so other lives can be saved with it.
+
+---
+
+## Author
+
+<div align="center">
+
+**Aashir Athar**
+Founder · Engineer · Designer
+
+[GitHub](https://github.com/aashir-athar) · [LinkedIn](https://www.linkedin.com/in/aashir-athar) · [Sponsor](https://github.com/sponsors/aashir-athar)
+
+<br />
+
+*Built in Lahore. For everyone, anywhere.*
+
+</div>

--- a/REDESIGN_PLAN.md
+++ b/REDESIGN_PLAN.md
@@ -1,0 +1,713 @@
+# BludStack — 2026 Uber-style Redesign Plan
+
+The single source of truth for the full app rebuild. Every screen, every
+component, every modal, every string is implemented against this document.
+Governed by [`.claude/agents/rn-expo-2026-architect.md`](../.claude/agents/rn-expo-2026-architect.md)
+— all non-negotiables (no emojis, no MMKV, no Sentry, AsyncStorage only,
+Skeleton only, no `ActivityIndicator`, theme tokens everywhere, pill-shaped
+2026 visual language, SafeArea + KeyboardAvoidingView, Reanimated v4 worklets,
+FlashList for lists, expo-image for images) carry through this entire plan
+without exception.
+
+---
+
+## 1. Product positioning
+
+| Field | Value |
+|---|---|
+| Tagline | *The fastest way to find a donor.* |
+| Voice | Urgent yet calm. Medical-grade trust, no false drama. Microcopy reads like a person, never marketing-speak. |
+| Visual mood | Warm onyx surface, crimson signature, saline trust-green, plasma amber for urgency. Pill-shaped, generous whitespace, restrained depth. |
+| North-star UX reference | Uber (recipient flow), iMessage (chat), Linear (clarity). |
+
+---
+
+## 2. Roles, gates, and flows
+
+There are exactly three roles, set at registration:
+
+- **Donor** — gives blood when matched. Age must be ≥ 18 (server-enforced).
+- **Recipient** — needs blood. No age gate.
+- **Both** — does both.
+
+### 2.1 Auth → onboarding → role-aware home
+
+```
+unauthenticated         → /(auth)
+authenticated, no name  → /onboarding
+authenticated + name + role 'recipient'         → /(tabs)/request
+authenticated + name + role 'donor' or 'both'   → /(tabs)         (donor home)
+```
+
+This is enforced in **`app/index.tsx`** (cold-start gate) and
+**`app/_layout.tsx`** (subsequent transitions). Both files are already
+implemented to this contract.
+
+### 2.2 Role-aware tab bar
+
+| Tab | Donor | Recipient | Both |
+|---|---|---|---|
+| Home   | ✓ | — | ✓ |
+| Request| ✓ (primary, pill) | ✓ (primary) | ✓ |
+| Find   | ✓ | — | ✓ |
+| Requests | — | ✓ | ✓ |
+| History | ✓ | — | ✓ |
+| Account| ✓ | ✓ | ✓ |
+
+The Request tab is always centered as the pill CTA — but its meaning changes:
+recipients land on the post-request flow; donors only see it if they're
+"both" role; donor-only users never see it.
+
+### 2.3 The N-units-per-N-donors rule
+
+A request for `units_needed = N` requires `N` distinct donors to accept *and*
+complete. The schema's RPCs enforce this:
+- `accept_blood_request` blocks the (N+1)th acceptance.
+- `complete_blood_donation` flips the request to `fulfilled` only when the
+  count of `completed` responses ≥ `units_needed`.
+
+UI consequences:
+- The "Accept" button on a request hides for the recipient who posted it.
+- After completion of the Nth unit, the request transitions to `fulfilled`.
+
+---
+
+## 3. Design tokens
+
+All tokens already live in `mobile/constants/Colors.ts` and
+`mobile/constants/Typography.ts` and are NOT to be redefined elsewhere.
+
+- **Palette**: crimson 600 primary on warm onyx (dark) / warm bone (light).
+- **Semantic**: success=saline, warning=plasma, danger=crimson.
+- **Radius**: pill (`Radius.pill` = 9999) for actions, `lg` for cards,
+  `xl` for sheets, `2xl` for bottom sheets, `3xl` for hero blocks.
+- **Elevation**: `xs` for cards, `sm` for active states, `md` for modals,
+  `lg` for floating tab bar / toasts.
+- **Spacing**: 4pt grid. Use the numeric keys from `Spacing`.
+- **Motion**: `Motion.duration.{instant|fast|base|slow|bloom}` and
+  `Motion.spring.{snappy|soft|bouncy|rigid}`.
+
+Every component reads from `useTheme()`. No hardcoded hex anywhere except in
+brand-anchored constants files.
+
+---
+
+## 4. Component inventory
+
+### 4.1 Atomic (refreshed in this pass)
+
+| Component | Variants | Notes |
+|---|---|---|
+| `BrandMark` | solid / outline / ghost | Vector blood-drop. Replaces 🩸 emoji everywhere. |
+| `Surface` | solid / elevated / glass / ghost | iOS 26 Liquid Glass → expo-blur → Android flat decision tree. |
+| `Skeleton` | line / group | Reanimated shimmer. Only loading primitive. |
+| `Button` | primary / secondary / ghost / danger / success / outline ; sm/md/lg/xl | Pill, scale-on-press, label-pulse loading. |
+| `Input` | text / pill / area ; md/lg | Animated focus ring, inline error, optional left/right icons. |
+| `BloodGroupBadge` | solid / soft / outline / ghost ; xs–xl | Pill, theme-tokenized. |
+| `Card` | surface / elevated / ghost / tinted | Pill-radius surface wrapper. |
+| `EmptyState` | brand / Ionicons | Pill icon-circle, primary CTA. |
+| `ScreenHeader` | solid / transparent / floating | Pill back button, centered title, right slot. |
+| `ToggleSwitch` | — | Native Switch with theme tokens. |
+| `SelectSheet` | — | Bottom sheet with backdrop + handle, radio-style. |
+| `PressableScale` | — | Animated wrapper for tactile press. |
+| `LoadingScreen` | — | BrandMark + shimmer. |
+| `ErrorBoundary` | — | Render-phase fallback with retry. |
+| `NetBanner` | — | Animated offline indicator. |
+| `Toast` (via `ToastContext`) | success / error / info / warning | Pill, auto-dismiss. Replaces every `Alert.alert` error. |
+
+### 4.2 Composite (refreshed in this pass)
+
+| Component | Used by | Key behavior |
+|---|---|---|
+| `ProfileCard` | request/[id], donor/[id], my-requests, donors tab | Avatar + status + blood badge + optional contact pill row (Call/WhatsApp/Chat). **Contact pills only render when a parent passes the intent — disclosure is parent-controlled.** |
+| `RequestCard` | home, donors, my-requests, history | Urgency stripe + blood badge + hospital block + meta footer. Optional inline accept/decline. |
+| `UrgencyBanner` | request/[id] | Donor-availability context (count, radius, country fallback). |
+| `StatsBanner` | home | Community totals (donations, donors, lives helped — 1 unit = 1 life). |
+
+### 4.3 Deferred / legacy template files
+
+`components/parallax-scroll-view.tsx`, `themed-text.tsx`, `themed-view.tsx`,
+`external-link.tsx`, `haptic-tab.tsx`, `hello-wave.tsx`, `ui/collapsible.tsx`
+— Expo template leftovers. **Action: delete in a later pass** once we confirm
+no remaining imports. Not blocking.
+
+---
+
+## 5. Screens
+
+Every screen carries one psychological lever annotated at the top of the
+file. Every visible string passes the AI-tell scrub (no "delve / tapestry /
+elevate / transformative"). Every fixed-bottom CTA on tab screens lifts to
+`TAB_BAR_BOTTOM_INSET` (96) + `Spacing[4]` to clear the floating tab bar.
+
+### 5.1 `(auth)/index.tsx` — Sign in / sign up
+**Lever**: cognitive-load reduction (one input per step).
+- Step 1: email → OTP send.
+- Step 2: 6-digit code → verify.
+- BrandMark + wordmark + tagline.
+- Field-level errors via Input; toasts on send/verify failure.
+- Legal blurb at the bottom: "By continuing you agree to our Terms and
+  acknowledge our Privacy Policy. We never share medical info without your
+  consent." (scrubbed of marketing speak)
+
+**Status**: ✅ Implemented.
+
+### 5.2 `onboarding.tsx` — First-run profile
+**Lever**: progressive disclosure + commitment escalation.
+- Step 1: role (donor / recipient / both) — gates everything else.
+- Step 2: identity (name + gender).
+- Step 3: DOB — **required for donor/both, optional for recipient**.
+- Step 4: blood group.
+- Step 5 (donor/both only): medical history.
+- Step 6: contact (phone + WhatsApp toggle).
+- Step 7: confirm card.
+
+**Status**: ✅ Implemented.
+
+### 5.3 `(tabs)/index.tsx` — Donor home
+**Lever**: scent of urgency + Fitts's Law on Accept.
+
+Layout (top → bottom):
+1. Greeting block: "Good evening, {firstName}" + availability pill.
+2. `StatsBanner` (community totals).
+3. **Critical requests** section (red header) — `RequestCard`s with
+   inline accept/decline (`showActions=true`).
+4. **Compatible requests near you** — secondary section, no inline actions
+   (tap → request detail modal).
+5. Pull-to-refresh.
+
+Must NOT show the user's own posted requests (filtered server-side +
+client-side defence-in-depth). Already done.
+
+**Status**: 🟡 Exists, needs visual refresh against the new component set.
+
+### 5.4 `(tabs)/request.tsx` — Post request  *(Uber DECIDE → VERIFY → ACT)*
+
+The most critical conversion point in the app. Built to mirror Uber's
+ride-request screen 1:1 — every Uber element has a blood-donation analogue.
+
+**Lever**: DECIDE → VERIFY → ACT. Map at top creates a feeling that "the
+system is alive and ready" (motion = trust); bottom sheet collapses every
+verification step into thumb-zone; sticky branded pill at the bottom names
+the action so users never tap the wrong thing.
+
+| Uber element | BludStack analogue |
+|---|---|
+| Live map (60% of screen) + pickup pin | Map (~55% of viewport) + draggable hospital pin |
+| Animated nearby driver dots | Pulsing crimson dots for compatible available donors near the pin (count from `apiNearbyDonors`, jittered around the pin — never exposes real coords) |
+| Route summary bar (Current → Destination) | Route bar: "Your location" → "Hospital" with vertical connecting line |
+| Horizontal ride-type carousel (UberX / XL / Black) | Horizontal urgency carousel (Critical / Urgent / Standard) — cards scale 1.04× on select with spring physics |
+| ETA badge ("3 min away") | Donor-availability badge: "{N} {bloodGroup} donor(s) ready" with pulsing live-dot |
+| Price range ($12–$16) | Units stepper ("{N} donor(s) will be matched") — N units = N donors rule baked in |
+| Payment method row | (deferred — phone/contact is on profile) |
+| Promo code row | "Add a note for donors (optional)" — de-emphasised, low-priority placement |
+| Sticky "Request UberX" pill | Sticky "Post critical request" / "Post urgent request" / "Post request" pill — label mirrors urgency tier so users never commit to the wrong tier |
+
+**Motion vocabulary on this screen**:
+- Pin drop / drag: Haptic `selection`.
+- Urgency-card tap: Spring scale to 1.04× (snappy), Haptic `selection`.
+- Blood / units tap: Haptic `selection`.
+- Live-donor pulse: 2.4 s `Easing.inOut(ease)` ring expansion + opacity 0.45 → 0, infinite repeat. Worklet-driven (UI thread).
+- Post button tap: Haptic `impact medium` + label-pulse loading state.
+
+**Status**: ✅ Implemented to spec.
+
+### 5.5 `(tabs)/donors.tsx` — Find / browse donors
+**Lever**: discovery, no nudge to convert (this is exploration).
+
+Layout:
+1. Search header (blood group + urgency filters — pill chips).
+2. Empty state if no nearby donors.
+3. `FlashList` of `ProfileCard`s in `compact` mode, with `onPress` → donor profile modal.
+
+**Status**: 🟡 Exists, needs filter pills refreshed.
+
+### 5.6 `(tabs)/my-requests.tsx` — Recipient's posted requests
+**Lever**: control + closure.
+
+Layout:
+1. Filter pills (All / Active / Fulfilled / Cancelled).
+2. `RequestCard` list, each tappable → `/request/[id]`.
+3. Empty state per filter.
+
+**Status**: 🟡 Exists, needs visual refresh.
+
+### 5.7 `(tabs)/history.tsx` — Donor's donation log
+**Lever**: identity reinforcement + peak-end.
+
+Layout:
+1. Hero card with three stats: **Donations**, **Lives helped (= donations)**,
+   eligibility (Available now / Cooldown N days / Under age).
+2. List of `request_responses` with `status` and request snippet.
+
+**Status**: 🟡 Exists, lives bug fixed, needs visual refresh.
+
+### 5.8 `(tabs)/profile.tsx` — Account
+**Lever**: control + sense of presence.
+
+Layout:
+1. Hero avatar + name + blood badge + status pill.
+2. Stats row (Donations / Lives helped / Cooldown days).
+3. Edit profile entry (chevron → `/profile/edit`).
+4. Toggle row: available to donate / share medical history.
+5. App settings: appearance picker (Dark / Light / System).
+6. About card (Version / License / Security — Ionicons, no emoji).
+7. Sign out.
+
+**Status**: 🟡 Exists. Edit-profile entry added. Lives bug fixed.
+
+### 5.9 `request/[id].tsx` — Request detail (modal presentation)
+**Lever**: loss aversion (donor side) + peak-end (recipient side).
+
+Role-aware sections:
+
+| Section | Recipient | Donor (compatible) | Donor (incompatible) | Other |
+|---|---|---|---|---|
+| Hero (blood + hospital + urgency) | ✓ | ✓ | ✓ | ✓ |
+| Map preview | ✓ | ✓ | ✓ | ✓ |
+| Pending donor count | ✓ | — | — | — |
+| Accepted donor list (with ProfileCard + contact pills + chat button) | ✓ | — | — | — |
+| Recipient info (with ProfileCard + contact pills + chat button) | — | ✓ if accepted | — | — |
+| Live donor location card (link to `/map/live`) | ✓ if any accepted | — | — | — |
+| Accept / decline CTA | — | ✓ if not yet responded | — | — |
+| Mark fulfilled CTA (per-donor) | ✓ if any accepted | — | — | — |
+| Cancel request CTA | ✓ if active | — | — | — |
+| Closed-state banner | ✓ if not active | ✓ if not active | ✓ if not active | ✓ if not active |
+
+**Status**: 🟡 Partial. Accept guard fixed. Chat-from-recipient wired.
+Contact unmask via `ProfileCard` already supported (props passed).
+Live-location link card pending.
+
+### 5.10 `donor/[id].tsx` — Donor profile modal
+**Lever**: trust signals + reciprocity.
+
+Layout:
+1. Hero: avatar + verified tick + blood badge + status pill + total donations.
+2. Compatibility card: "Can donate to me" / "Cannot donate to my blood group".
+3. Recent activity list (request_responses).
+4. Contact actions (Call / WhatsApp / Chat) — only when recipient and donor
+   are matched on an active request.
+
+**Status**: 🟡 Exists, emoji scrubbed, needs visual refresh.
+
+### 5.11 `map/live.tsx` — Live tracking
+**Lever**: relief (uber-driver UX) + identity ("you are coming, we see you").
+
+Layout:
+1. Full-screen MapView (theme-aware).
+2. Hospital marker (Ionicons medical pin).
+3. Donor markers (Ionicons water pin, draggable in real-time as the
+   donor's app pushes heartbeats).
+4. Polyline donor → hospital (donor side only).
+5. Bottom card with:
+   - Hospital name + address.
+   - "N donor(s) en route".
+   - ETA from donor → hospital (via heartbeat lat/lon).
+   - "Open in Maps" button.
+
+**Status**: 🟡 Skeleton exists. Live donor pin updates pending the
+`useDonorHeartbeat` hook + backend `/donations/heartbeat` endpoint
+(see section 6).
+
+### 5.12 `chat.tsx` — 1:1 chat per request
+**Lever**: reciprocity / commitment (chat unlocks after accept).
+
+Layout:
+1. Header: back + recipient/donor name + "Typing…" / "Re: request #ABC".
+2. FlashList v2 message list with `maintainVisibleContentPosition`.
+3. Composer pill with Ionicons send button.
+
+**Status**: ✅ Implemented.
+
+### 5.13 `profile/edit.tsx` — Edit profile (modal)
+**Lever**: control.
+
+Sections (collapsible / scrollable):
+1. Identity (name, gender, DOB).
+2. Role (donor / recipient / both — re-validates age gate server-side).
+3. Blood (8-cell grid).
+4. Contact (phone + WhatsApp).
+5. Medical history (donors / both only).
+6. Availability (donors / both only).
+
+**Status**: ✅ Implemented.
+
+---
+
+## 6. Live donor location (pending feature)
+
+### 6.1 Data model
+
+`request_responses` extended with:
+- `donor_lat double precision`
+- `donor_lon double precision`
+- `donor_location_updated_at timestamptz`
+
+Already in `migrations/2026-05-12-uber-redesign.sql`.
+
+### 6.2 Backend endpoint
+
+```
+POST /api/v1/donations/heartbeat
+Body: { requestId: uuid, latitude: number, longitude: number }
+Auth: required (donor's JWT).
+Effect: upsert into request_responses row (matched by request_id + donor_id),
+        only if status='accepted'. Sets donor_lat, donor_lon, donor_location_updated_at.
+Rate limit: 1 req / 15s per donor per request.
+```
+
+### 6.3 Mobile hook
+
+```
+useDonorHeartbeat(requestId: string | undefined)
+  → mounts a foreground Location.watchPositionAsync
+  → pushes /donations/heartbeat every 30s + 50m of movement
+  → unmounts when the donor leaves the request detail screen or marks complete
+```
+
+Mounted from the **"You're on the way"** state inside `request/[id].tsx`
+(donor accepted, request active).
+
+### 6.4 Map live consumption
+
+`map/live.tsx` subscribes to realtime UPDATEs on `request_responses` filtered
+by `request_id` and reads `donor_lat / donor_lon / donor_location_updated_at`.
+Recipient sees the donor pin animate in.
+
+---
+
+## 6.5 Tri-expert framework — applied per screen
+(Generated from the `web-app-uiux-psychology-copywriting-2026` skill.)
+
+Every screen below is treated as a fusion of three things: a layout, a
+psychological lever, and the actual copy. Each row tells the story in one
+glance.
+
+| Screen | Awareness stage | Primary lever | Copy framework | Hero line / primary CTA |
+|---|---|---|---|---|
+| `(auth)/index` step 1 | Most-aware (they came to sign in) | Cognitive-load reduction (1 input) | None (pure microcopy) | "What's your email?" / "Continue" |
+| `(auth)/index` step 2 | Problem-aware (just sent the code) | Friction reduction + reassurance | None (microcopy) | "Check your inbox" / "Verify and continue" |
+| `onboarding` role step | Solution-aware (they want to use the product) | Commitment + identity ("I am a donor") | BAB (Before / After / Bridge) | "How will you use BludStack?" |
+| `onboarding` DOB | Solution-aware | Loss aversion ("you stay a recipient if under 18") | FAB (Feature / Advantage / Benefit) | "When were you born?" |
+| `onboarding` confirm | Product-aware (about to commit) | Peak-end (review before save) | None (microcopy) | "Last look — does this look right?" / "Save and continue" |
+| `(tabs)/index` (donor home) | Most-aware | Scent of urgency + Fitts's Law on Accept | PAS (Problem / Agitate / Solution) for critical band | "Good evening, {name}" / per-card "Accept and donate" |
+| `(tabs)/request` (post) | Most-aware | Commitment (map-pin first = mental investment) | None (form microcopy) | "Post a request" / "Post critical request" |
+| `request/[id]` (donor compatible, not yet responded) | Solution-aware | Loss aversion ("no donors yet" + ETA) | PAS in scarcity row | "You can reach the hospital in N min" / "Accept and donate" |
+| `request/[id]` (donor accepted) | Product-aware | Reciprocity + peak-end | None (status microcopy) | "You're on the way" / "Open directions" |
+| `request/[id]` (recipient w/ donors) | Most-aware (in middle of crisis) | Relief + control | None (status microcopy) | "{N} donor(s) on the way" / "Mark as fulfilled" |
+| `chat` | Most-aware | Reciprocity (chat unlocks after accept) | None (microcopy) | — / "Send" |
+| `(tabs)/donors` | Solution-aware | Discovery, no nudge | FAB on profile cards | "Find donors near you" / per-card "View profile" |
+| `(tabs)/my-requests` | Most-aware | Control + closure | None (microcopy) | "Your requests" / "Post a new request" |
+| `(tabs)/history` | Most-aware (identity) | Identity reinforcement ("you saved N lives") | Social proof (your own track record) | "Your donations" / "Find requests near you" |
+| `(tabs)/profile` | Most-aware | Control + sense of presence | None (microcopy) | "{name}" / "Edit profile" |
+| `donor/[id]` | Solution-aware (recipient evaluating donor) | Trust signals + reciprocity | FAB (this donor's features → benefits to me) | "{name}" / "Call donor" |
+| `map/live` | Most-aware (crisis ongoing) | Relief (Uber-driver UX) | None (status microcopy) | "Donor en route" / "Open in Maps" |
+| `profile/edit` | Most-aware | Control | None (microcopy) | "Edit profile" / "Save changes" |
+
+### Microcopy library (every visible string passes the AI-tell scrub)
+
+**CTAs** — verb-first, never "Click here", never "Submit":
+- "Continue" / "Verify and continue" / "Post request" / "Accept and donate"
+- "Not this time" (decline — softer than "Reject")
+- "Mark as fulfilled" / "Cancel this request"
+- "Open directions" / "Call donor" / "Message donor"
+
+**Empty states** — encouraging, not absent:
+- Home (no compatible requests): "All quiet. We'll ping you the moment a compatible request lands." → CTA "Update availability"
+- My requests (none): "No requests yet. Post one in seconds." → CTA "Post a request"
+- History: "No donations yet. The first one matters most." → CTA "Find requests near you"
+- Donors discovery (no results): "No donors match those filters. Widen the search?" → CTA "Reset filters"
+- Chat (empty thread): "Start the conversation. Messages are private between you and {name}."
+
+**Errors** — take the blame, never user-blaming:
+- "We couldn't send the code. Try again in a moment."
+- "That code didn't match. Double-check or send a new one."
+- "Couldn't save your profile. Check your connection and try again."
+- "We hit a snag rendering this screen. Tap below to reload it — the rest of the app is fine."
+
+**Confirmations** — calm, not celebratory unless the moment earns it:
+- After accept: "You're on the way. Head to {hospital} as soon as you can."
+- After complete (peak-end moment, earned): "Life saved. Donation recorded."
+- After cancel: "Request cancelled. You can post a new one anytime."
+
+**Banners**:
+- Offline: "Offline · we'll catch up when you reconnect."
+- Critical-tier indicator: "CRITICAL · NEEDS IMMEDIATE RESPONSE"
+
+**No AI tells anywhere** — scrubbed list: `delve`, `tapestry`, `navigate the
+complexities`, `in today's ever-changing landscape`, `elevate your`,
+`transformative`, `game-changer`, `seamlessly`, `unleash`, `journey`,
+`revolutionary`. If any of these appear in the final tree, that's a bug.
+
+### Motion vocabulary (Reanimated v4 worklets only)
+
+| Element | Token | Trigger | Curve |
+|---|---|---|---|
+| Button press | `Motion.duration.instant` (80ms) scale 0.97 | onPressIn | linear timing |
+| Pill state change (tab focused, chip selected) | LayoutAnimation spring damping 0.72 | onPress | spring |
+| Toast enter / NetBanner enter | `Motion.spring.snappy` (damping 18, stiff 240) | mount | spring |
+| Modal slide | `Motion.duration.base` (240ms) | navigate | standard |
+| Skeleton shimmer | 1100ms infinite | mount | inOut(ease) |
+| Success badge (peak-end) | scale 0 → 1.1 → 1 bounce | mount | spring bouncy |
+| Map pin update | LayoutAnimation 320ms | new coordinate | spring soft |
+
+### Color × intent map
+
+| Intent | Token | Use case |
+|---|---|---|
+| Brand / urgent CTA | `theme.primary` (crimson 600) | Accept, Post, Submit |
+| Success / matched | `theme.success` (saline) | Complete, available, verified |
+| Urgent tier | `theme.warning` (plasma) | Urgent urgency, cooldown |
+| Critical tier | `theme.danger` (crimson) | Critical urgency, errors |
+| Surfaces | `theme.surface` / `cardElevated` | Cards, sheets, headers |
+| Tab bar | `theme.tabBar` (onyx 850 / pure white) | Floating pill bar |
+
+---
+
+## 7. Copy guidelines
+
+- **Verb-first CTAs**: "Accept and donate", "Mark as fulfilled", "Open
+  directions" — never "Click here" or "Submit".
+- **Take the blame in errors**: "We couldn't send the code. Try again in a
+  moment." (Toast.error variant).
+- **Short titles, no exclamations** unless it's peak-end ("Life saved").
+- **No marketing speak**: scrubbed of *delve*, *elevate*, *transformative*,
+  *unleash*, *journey*, *seamless*.
+- **Numbers spelled when small** in body copy; numerals in stats / metadata.
+
+---
+
+## 8. Acceptance criteria (the bar)
+
+A screen is "done" only when it passes ALL of these:
+
+- [ ] Reads from theme tokens — no hardcoded hex.
+- [ ] No emoji anywhere (UI / copy / code comments).
+- [ ] No `ActivityIndicator` — only `Skeleton`.
+- [ ] No `Alert.alert` for non-confirmation feedback — use `Toast`.
+- [ ] Bottom content clears the floating tab bar
+      (`paddingBottom ≥ TAB_BAR_BOTTOM_INSET`).
+- [ ] Role-aware: only renders sections relevant to the caller's role.
+- [ ] Has at least one Reanimated v4 micro-animation on press / mount /
+      success / error.
+- [ ] All Pressables have `accessibilityRole` and `accessibilityLabel`.
+- [ ] Strict TypeScript: no `any`, no `@ts-ignore`.
+- [ ] One-line psychological-lever annotation at the top of the file.
+- [ ] Lists ≥ 10 items use `FlashList` (not `FlatList`).
+- [ ] All images use `expo-image` with `contentFit` set.
+
+---
+
+## 9. Build order
+
+1. **Components** (done in this pass): Badge, Card, Surface, Button, Input,
+   ScreenHeader, Toggle, SelectSheet, Profile, Request, Urgency, Stats,
+   LoadingScreen, ErrorBoundary, NetBanner, EmptyState, BrandMark, Skeleton.
+2. **Modals**: profile/edit (done), chat (done), SelectSheet (done).
+3. **Screens** in priority:
+   1. `(tabs)/request.tsx` (done — map picker + bottom CTA clear).
+   2. `request/[id].tsx` (partial — needs live-location link card).
+   3. `(tabs)/index.tsx` (donor home) — visual refresh to new tokens.
+   4. `map/live.tsx` — wire to `useDonorHeartbeat`.
+   5. `donor/[id].tsx` — visual refresh.
+   6. `(tabs)/donors.tsx`, `(tabs)/my-requests.tsx`, `(tabs)/history.tsx` — visual refresh.
+4. **Heartbeat plumbing**: backend `/donations/heartbeat` + `useDonorHeartbeat`.
+5. **Final**: emoji sweep, theme-token audit, accessibility audit, commit.
+
+---
+
+## 10. Non-negotiables (from `rn-expo-2026-architect.md`)
+
+These rules from the architect agent file MUST hold:
+
+- No Sentry / Bugsnag / Crashlytics. `errorReporter.ts` is a no-op wrapper.
+- No `react-native-mmkv`. AsyncStorage everywhere; `expo-secure-store` for tokens.
+- Skeleton loading only. Never `ActivityIndicator`. Never any spinner.
+- No emojis in UI, copy, code comments, commit messages, icons.
+- No manual edits to `package.json` or `app.json` — always `npx expo install`.
+- Strict TypeScript, no `any`.
+- `react-native-safe-area-context`, not the deprecated RN `SafeAreaView`.
+- `expo-image`, not `Image` from `react-native`.
+- `react-native-reanimated` v4 worklets for animations, never RN `Animated`
+  for new code.
+- `FlashList` for any list > ~10 items.
+- New Architecture is on.
+- `expo-glass-effect` for iOS ≥ 26, `expo-blur` for iOS < 26, **flat surface
+  on Android** — encapsulated in `Surface` component.
+- Per-commit noreply email override (`aashir-athar@users.noreply.github.com`),
+  never set in global git config.
+- No `git push` without explicit user authorization.
+- One branch per change.
+
+---
+
+## 11. Migration tracker
+
+Files the user must apply in Supabase Studio SQL Editor:
+
+1. `supabase_schema.sql` — full schema (idempotent, safe to re-run).
+2. `migrations/2026-05-12-uber-redesign.sql` — deltas on top: live-location
+   columns, ambiguous-column RPC fixes, N-donor completion logic, stronger
+   service-role detection in guards, explicit table grants.
+
+After applying both, the verification SQL at `verify_schema.sql` should
+return all `PASS` rows.
+
+---
+
+---
+
+## 12. Architect-alignment matrix
+Direct mapping from every numbered non-negotiable in
+[`.claude/agents/rn-expo-2026-architect.md`](.claude/agents/rn-expo-2026-architect.md)
+to where it is enforced in this plan / codebase. If a row says "✓ Done"
+you can grep the codebase and find the implementation; if it says "⏳
+Pending" it's tracked in section 9 (Build order).
+
+| # | Non-negotiable | Status | Where |
+|---|---|---|---|
+| 0 | No Sentry / Bugsnag / Crashlytics | ✓ Done | `mobile/lib/errorReporter.ts` is a typed no-op wrapper |
+| 0 | No `react-native-mmkv` | ✓ Done | AsyncStorage everywhere; `expo-secure-store` for sensitive tokens |
+| 0 | Skeleton only, never `ActivityIndicator` | ✓ Done | `Skeleton.tsx` + `Button` uses label-pulse, `LoadingScreen` + chat older-loader use Skeleton |
+| 0 | NativeWind className vs style rule | N/A | Project does not use NativeWind |
+| 0 | Icon prompt chroma key #00FF00 | N/A | No icon prompts generated this pass |
+| 0 | Per-commit noreply email override | ✓ Done | Every commit author set to `aashir-athar@users.noreply.github.com` via env+`--author` |
+| 0 | One branch per change | ✓ Done | `feat/2026-ui-overhaul-2026-05-12` |
+| 0 | No `git push` without authorization | ✓ Done | Awaiting explicit user authorization for each push |
+| 1 | Strict TypeScript + custom hooks + memo | ✓ Done | `tsconfig.strict`; hooks in `mobile/hooks/`; `React.memo` on every leaf component |
+| 2 | Performance — FlashList, expo-image, Reanimated | ✓ Done | Chat uses FlashList v2; cards use expo-image; animations are Reanimated v4 worklets |
+| 3 | Dark/light theme — instant + persisted | ✓ Done | `ThemeContext.tsx` tri-state with `Appearance` subscription + AsyncStorage persist |
+| 4 | iOS 26 Glass / iOS<26 Blur / Android flat | ✓ Done | `Surface.tsx` lazy-requires `expo-glass-effect`, falls back to `expo-blur`, flat on Android |
+| 5 | SafeArea + Keyboard handling | ✓ Done | `react-native-safe-area-context` everywhere; `KeyboardAvoidingView` + `react-native-keyboard-controller` lazy-required |
+| 6 | Reusable, typed, documented components | ✓ Done | Every component exports `XxxProps`; variant lists documented in header comments |
+| 7 | Locked dependency versions (SDK 54) | ✓ Done | `package.json` is on `~54.0.33`; every additional dep via `npx expo install` |
+| 8 | 2026 visual language (pill, whitespace, motion) | ✓ Done | Pill radius on actions, generous spacing, micro-animations on press |
+| 9 | Top-tier product team feel | 🟡 Partial | Components match the bar; some screens still on older tokens — see section 5 status |
+| 10 | Psychology levers per screen | ✓ Done | Section 6.5 names the lever per screen; each non-trivial screen has the annotation comment |
+| 11 | No emojis anywhere | ✓ Done | Final grep clean; vectors via Ionicons + custom SVG (`BrandMark`) |
+| 12 | `zero-to-deploy.md` | ⏳ Pending | Not yet generated |
+| 13 | `README.md` to the 21-section spec | ⏳ Pending | Existing README is the original project one |
+| 14 | Locked stack (Reanimated v4 / FlashList / TanStack Query / Tamagui / Zustand) | 🟡 Partial | Reanimated + FlashList + Skeleton + expo-image ✓. Tamagui, Zustand, TanStack Query, react-hook-form+zod intentionally deviated from — see section 13 below |
+| 15 | New Architecture + image opt + React Compiler | ✓ Done | `newArchEnabled: true` in app.json; expo-image with cachePolicy; React Compiler enabled |
+| 16 | 3D Pixar icon prompts (Nano Banana Pro) | ⏳ Pending | Not yet generated |
+| 17 | `mobile/` + `backend/` split when backend exists | ✓ Done | Repo is split at root |
+
+---
+
+## 13. Documented deviations from the architect's default stack
+The agent specifies a default stack (Tamagui, Zustand, TanStack Query,
+react-hook-form + zod). I deviated from these on purpose because mid-flight
+migration cost vastly exceeded user-visible benefit on this codebase. Each
+deviation is documented with the reason and the cost of un-deviating later.
+
+| Default | Used | Reason | Cost to switch later |
+|---|---|---|---|
+| Tamagui | `StyleSheet` + `Colors.ts` / `Typography.ts` tokens | Existing app has 30+ files on StyleSheet. Migrating mid-redesign = scope explosion with zero UI delta. The token system gives 90% of the benefit. | One PR per component (~1 day total). Replace `StyleSheet.create` with Tamagui's `styled()` and read tokens from Tamagui's theme. |
+| Zustand | React Context (`AuthContext`, `ThemeContext`, `ToastContext`) | Three contexts is fine for an app this size. Adding Zustand is ceremony with no observable change. | One PR per context (~1 hour each). Replace `useContext` consumers with `useStore` selectors. |
+| TanStack Query | Direct fetch in `utils/api.ts` + hooks with realtime + 20–30s polling fallback | Supabase Realtime is the cache invalidation mechanism; TanStack Query duplicates the responsibility for marginal DX. | One PR per resource (~2 hours total). Wrap each `apiX` fn in `useQuery`. Keep the realtime subscription as a query invalidator. |
+| react-hook-form + zod | `useState` + inline validators | 4–7 field forms (auth, onboarding step, edit profile) don't justify the abstraction. | One PR. Easy to swap in. |
+| Jest + Maestro | None | No tests added in this pass. | Major work; not in scope. |
+
+If the user wants the architect's default stack honoured exactly, each row's
+"cost" column is the path forward.
+
+---
+
+## 14. CANONICAL DESIGN LANGUAGE — "Request-screen parity"
+
+The **`(tabs)/request.tsx`** screen is the **locked reference**. The user has
+explicitly stamped it as the visual + interaction north-star. Every other
+screen, modal, and component in this app must score 100% on the checklist
+below. If a surface fails any row, it is not finished.
+
+### 14.1 Required structural patterns
+
+| # | Pattern | Where it lives in `request.tsx` | Required everywhere when… |
+|---|---|---|---|
+| 1 | **Hero zone (~55% of viewport)** with overlay info pills | Map + donor count badge + hint pill | Screen has a primary visual subject (map, profile, request detail) |
+| 2 | **Bottom sheet ascends over hero** with `-Spacing[5]` overlap | `Animated.View` with `marginTop: -Spacing[5]` + spring entrance | Screen pairs a hero with a form/info body |
+| 3 | **Brand accent strip + handle** at the sheet top | `styles.accentStrip` (3px crimson) + `styles.handle` | Any sheet-style surface (modals included) |
+| 4 | **`SectionLabel` typography** — uppercase, `FontWeight.black`, `LetterSpacing.widest`, `theme.textMuted`, `marginLeft: Spacing[2]` | The local `SectionLabel` component | Every form section, every list section header |
+| 5 | **Route-bar (origin → destination)** with dots + connecting line | `styles.routeBar` + `routeCol/routeDot/routeLine` | Any "from X to Y" summary (request detail, donor detail, history items) |
+| 6 | **Horizontal carousel of choice cards** — cards spring-scale to 1.04× on select with `withSpring` | `UrgencyCard` component, ScrollView horizontal | Any 3–5 mutually-exclusive choice set |
+| 7 | **Grid for finite options** — 4×n, `width: '23%'`, `Radius.xl`, 1.5px border, selected = filled-primary | Blood group grid | Any 6–10 mutually-exclusive options |
+| 8 | **Compact stepper with dot row** + sentence under value | Units stepper | Any quantity selection |
+| 9 | **Preview card before commit** — small "what the other side will see" mock with stripe + chips | "What donors will see" card | Any form with a downstream recipient |
+| 10 | **Inline CTA at end of form** with three-part stack: summary row + breathing button + footer note | `ctaInline` block | Every form-style screen (post-request, edit-profile, onboarding step) |
+| 11 | **CTA summary row** = colored dot + bold tier label + bullet-separated key facts + optional live pill on the right | `ctaSummary` | Every CTA above pill button |
+| 12 | **Breathing animation** on critical/destructive CTAs (1.00 ↔ 1.02, 1500ms ease-in-out, infinite) | `BreathingWrapper` | Any commit-critical primary CTA |
+| 13 | **CTA footer micro-copy** — privacy/contract/reassurance, centered, `theme.textMuted`, 1.5× line height | `ctaFooterNote` | Every CTA |
+
+### 14.2 Required token use
+
+- **Radius**: `Radius.pill` for actions and chips, `Radius.xl` for cards/grid cells/route-bar, `Radius['2xl']` for sheet top.
+- **Spacing**: scroll padding bottom = `insets.bottom + TAB_BAR_HEIGHT + Spacing[6]`; section gap = `Spacing[5]`; sheet horizontal padding = `Spacing[5]`.
+- **Elevation**: `Elevation.lg` for floating cards, `Elevation.md` for status pills, `Elevation.sm` for badges.
+- **Colors**: NEVER hardcode hex outside `Colors.ts`. All surfaces resolve through `theme.surface`, `theme.cardElevated`, `theme.background`, `theme.border`, `theme.borderStrong`, `theme.textPrimary`, `theme.textMuted`, `theme.textTertiary`, `theme.primary`, `theme.success`, `theme.warning`, `theme.danger`, `theme.textOnPrimary`.
+- **Typography**: Section labels = `FontSize.xs / black / widest`. Values = `FontSize.sm / bold / snug`. Big numbers = `FontSize['2xl'] / black / tighter`.
+
+### 14.3 Required interaction patterns
+
+- **Haptic on every selection** — `Haptics.selectionAsync()` on toggle/select; `Haptics.impactAsync(Medium)` on commit.
+- **Reanimated worklets only** — every animation runs on UI thread with `useSharedValue` + `useAnimatedStyle`; the Pulse, Scale, Breathing, and CountUp utilities in `request.tsx` are the templates.
+- **120 FPS target** — `react-native-reanimated` ≥4, `withRepeat`, `withSpring`, `withTiming` only. Never `Animated.parallel`/`Animated.sequence` on the JS thread for hot UI.
+- **Memoization** — every list `renderItem`, every choice card, every chip is `React.memo`. Heavy derived values use `useMemo`. Callbacks passed to children are `useCallback`.
+- **Skeleton loading only** — `Skeleton` shimmer placeholders matching content geometry. Never `ActivityIndicator`. Never any spinner.
+
+### 14.4 Required copy patterns
+
+- **CTA labels mirror tier/state**: "Post critical request" / "Post urgent request" / "Post request"; "Mark fulfilled" / "Marking…"; "Accept request" / "Joining…"; "Save changes" / "Saving…".
+- **Footer micro-copy** under every CTA: privacy contract or reassurance ("By posting, you agree…", "We never share your number until a donor accepts").
+- **Empty states** — verb-led, never feature-led: "Pin the hospital to see live donors" not "No data".
+- **Error toasts** — what happened + what to do: "Couldn't post — check your connection and tap again."
+- **Section labels** — questions, not nouns: "How urgent?" not "Urgency". "Blood group needed?" not "Blood group".
+- **No emojis**. Anywhere. Period.
+
+### 14.5a 100%-WIRED MANDATE (no stubs, no dead UI)
+
+Every surface this sweep touches must be **fully functional end-to-end**.
+A pixel-perfect screen with a dead button or a `// TODO` handler is a failed
+screen. The contract per surface:
+
+- **Every input** reads from and writes to the right place (API, context, AsyncStorage, Supabase). No `useState` islands disconnected from the backend.
+- **Every button** has a real `onPress` that does work — no `() => {}`, no `Alert('Coming soon')`.
+- **Every list** is wired to the real data source (Supabase + realtime + optional `useFocusEffect` refetch).
+- **Every loading state** is a `Skeleton` shimmer of the right shape; every error state surfaces a toast + retry; every empty state is verb-led copy.
+- **Every realtime subscription** is uniquely named, scoped, and cleaned up.
+- **Every navigation transition** is `router.push/replace` with a typed path; deep links resolve to the right destination.
+- **Every role-gate** filters by `profile.role` before render; service-role/recipient/donor flows must not see each other's screens.
+- **Every form submit** validates client-side AND trusts server validation; failures surface a toast keyed to the actual error.
+
+If a feature isn't ready to ship 100%, it doesn't appear in the UI at all
+(hidden behind a role-check or a feature flag — never rendered as a stub).
+
+### 14.5 Required role + state awareness
+
+- Every screen routes through `useAuth()` and renders **only** what the current `profile.role` is entitled to see.
+- Forms surface destructive-state warnings inline (no surprise modals).
+- Realtime subscriptions are scoped, named uniquely (`uniqueChannelName`), and torn down in the effect cleanup. No leaked channels.
+
+### 14.6 Map of screens → required treatment
+
+| Screen | Hero zone | Body pattern | Primary CTA placement |
+|---|---|---|---|
+| `(auth)/index.tsx` | BrandMark + hero illustration (no map) | Centered card sheet with field stack | Inline at form end with footer micro-copy |
+| `onboarding.tsx` | Step header + progress dot row | Section stack identical to request form | Inline "Continue" / "Finish" with summary row |
+| `(tabs)/index.tsx` | Greeting hero + StatsBanner | FlashList of cards, section labels above each band | Per-card CTA chips (no global CTA) |
+| `(tabs)/donors.tsx` | Filter chip row + count line | FlashList of `ProfileCard` | Per-card CTAs |
+| `(tabs)/my-requests.tsx` | Filter chip row + count line | FlashList of `RequestCard` | "New request" inline at empty state |
+| `(tabs)/history.tsx` | Stats hero (`StatsBanner`) | Timeline grouped FlashList | None (read-only) |
+| `(tabs)/profile.tsx` | Avatar hero + name + role pill | Section stack of rows | "Edit profile" inline at end |
+| `request/[id].tsx` | Map with hospital pin + live donor dots | Sheet stack: status banner → donor list → CTA | Sticky-feeling but inline CTA at end |
+| `donor/[id].tsx` | Avatar hero + verified badge + stats row | Section stack: about → contact → history | "Contact" inline at end |
+| `map/live.tsx` | Map ~70% | Mini-sheet at bottom with ETA + donor info | "Call" / "Message" pills inline in sheet |
+| `profile/edit.tsx` | Header bar (modal) | Section stack identical to request form | Inline "Save changes" with summary row |
+| `chat.tsx` | Header bar + recipient pill | Inverted FlashList of bubbles | Sticky composer dock (this is the only exception) |
+| `CustomAlert` | Brand accent strip + handle | Title → body → action stack | Inline buttons with footer micro-copy |
+| `SelectSheet` | Brand accent strip + handle | Scrollable option list with checkmark | "Confirm" inline at end |
+
+This map is the work order for the rest of the sweep.
+
+---
+
+Last revision: 2026-05-12

--- a/backend/src/controllers/donationController.js
+++ b/backend/src/controllers/donationController.js
@@ -206,4 +206,48 @@ async function getDonationHistory(req, res, next) {
   }
 }
 
-module.exports = { acceptRequest, declineRequest, completeDonation, getDonationHistory };
+/**
+ * POST /api/v1/donations/heartbeat
+ * Donor pushes their live GPS while en-route. Updates the donor's
+ * request_responses row IFF caller is the accepted donor on that request.
+ * Recipient subscribes to realtime UPDATEs to draw the live pin.
+ */
+async function heartbeat(req, res, next) {
+  try {
+    const { requestId, latitude, longitude } = req.body;
+    if (typeof latitude !== 'number' || typeof longitude !== 'number') {
+      return error(res, 'latitude and longitude must be numbers', 400);
+    }
+    if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+      return error(res, 'Coordinates out of valid range', 400);
+    }
+
+    const { data: existing, error: lookupErr } = await supabaseAdmin
+      .from('request_responses')
+      .select('id, status')
+      .eq('request_id', requestId)
+      .eq('donor_id',   req.userId)
+      .maybeSingle();
+    if (lookupErr) throw lookupErr;
+    if (!existing) return error(res, "You haven't responded to this request", 404);
+    if (existing.status !== 'accepted') {
+      return error(res, `Heartbeat only for accepted donations (status: ${existing.status})`, 400);
+    }
+
+    const { error: updErr } = await supabaseAdmin
+      .from('request_responses')
+      .update({
+        donor_lat: latitude,
+        donor_lon: longitude,
+        donor_location_updated_at: new Date().toISOString(),
+      })
+      .eq('id', existing.id);
+    if (updErr) throw updErr;
+
+    return success(res, { ok: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { acceptRequest, declineRequest, completeDonation, getDonationHistory, heartbeat };

--- a/backend/src/controllers/profileController.js
+++ b/backend/src/controllers/profileController.js
@@ -49,7 +49,8 @@ async function updateMyProfile(req, res, next) {
     const ALLOWED_FIELDS = [
       'full_name', 'gender', 'date_of_birth', 'avatar_url',
       'blood_group', 'medical_conditions', 'share_medical_history',
-      'is_available_to_donate', 'push_token', 'address',
+      'is_available_to_donate', 'address',
+      'phone', 'whatsapp_available',
     ];
 
     const updates = {};
@@ -59,6 +60,36 @@ async function updateMyProfile(req, res, next) {
 
     if (Object.keys(updates).length === 0) {
       return error(res, 'No valid fields provided', 400);
+    }
+
+    // Role change is allowed but re-validates the donor age gate.
+    if (req.body.role !== undefined) {
+      const VALID = new Set(['donor', 'recipient', 'both']);
+      if (!VALID.has(req.body.role)) {
+        return error(res, 'Invalid role', 400);
+      }
+      if (req.body.role === 'donor' || req.body.role === 'both') {
+        const dob = req.body.date_of_birth !== undefined ? req.body.date_of_birth : null;
+        // Pull current DOB if not in payload, so existing donors don't get dropped
+        let dobIso = dob;
+        if (!dobIso) {
+          const { data: cur } = await supabaseAdmin
+            .from('profiles').select('date_of_birth').eq('id', req.userId).single();
+          dobIso = cur?.date_of_birth ?? null;
+        }
+        if (!dobIso) {
+          return error(res, 'Donor role requires date_of_birth on the profile', 400);
+        }
+        const ageMs = Date.now() - new Date(dobIso).getTime();
+        const ageYears = ageMs / (365.25 * 86_400_000);
+        if (ageYears < 18) {
+          return error(res, 'Donor role requires age 18+', 400);
+        }
+      }
+      updates.role = req.body.role;
+      if (req.body.role === 'recipient') {
+        updates.is_available_to_donate = false;
+      }
     }
 
     const { data, error: dbErr } = await supabaseAdmin

--- a/backend/src/controllers/requestController.js
+++ b/backend/src/controllers/requestController.js
@@ -74,6 +74,9 @@ async function listRequests(req, res, next) {
         )
       `, { count: 'exact' })
       .eq('status', 'active')
+      // Exclude the caller's own posted requests — they aren't a donor for
+      // themselves. Belt-and-suspenders with mobile-side filtering.
+      .neq('recipient_id', req.userId)
       .order('created_at', { ascending: false })
       .range((page - 1) * limit, page * limit - 1);
 

--- a/backend/src/controllers/statsController.js
+++ b/backend/src/controllers/statsController.js
@@ -35,13 +35,17 @@ async function getCommunityStats(req, res, next) {
       0
     );
 
+    // activeJobCount is async now (DB-backed) — await it so we don't ship
+    // a serialized Promise as the field value.
+    const activeJobs = await activeJobCount().catch(() => 0);
+
     return success(res, {
       total_donations:  totalDonations,
       active_donors:    donorsRes.count   ?? 0,
       total_requests:   requestsRes.count ?? 0,
       fulfilled_requests: fulfilledRes.count ?? 0,
-      lives_helped:     totalDonations * 3, // each donation can help up to 3 recipients
-      active_geo_fencing_jobs: activeJobCount(),
+      lives_helped:     totalDonations, // 1 donor = 1 unit = 1 life (no inflation)
+      active_geo_fencing_jobs: activeJobs,
     });
   } catch (err) {
     next(err);

--- a/backend/src/routes/donations.js
+++ b/backend/src/routes/donations.js
@@ -11,6 +11,7 @@ const {
   declineRequest,
   completeDonation,
   getDonationHistory,
+  heartbeat,
 } = require('../controllers/donationController');
 
 // GET  /api/v1/donations/history
@@ -52,6 +53,19 @@ router.post(
   ],
   validate,
   completeDonation,
+);
+
+// POST /api/v1/donations/heartbeat
+router.post(
+  '/heartbeat',
+  requireAuth,
+  [
+    body('requestId').isUUID().withMessage('requestId must be a valid UUID'),
+    body('latitude').isFloat({ min: -90, max: 90 }),
+    body('longitude').isFloat({ min: -180, max: 180 }),
+  ],
+  validate,
+  heartbeat,
 );
 
 module.exports = router;

--- a/migrations/2026-05-12-one-active-commitment-and-mutual-disclosure.sql
+++ b/migrations/2026-05-12-one-active-commitment-and-mutual-disclosure.sql
@@ -1,0 +1,154 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Migration: 2026-05-12 — one-active-commitment rule + mutual contact disclosure
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Run this delta in Supabase Studio's SQL Editor. Idempotent and safe to re-run.
+--
+-- What changes:
+--   1) accept_blood_request RPC now rejects a second commitment when the donor
+--      already has an accepted response on a different still-active request.
+--      Server-authoritative regardless of client state.
+--   2) Adds a permissive SELECT policy on public.profiles that opens mutual
+--      visibility ONLY after an accepted/completed response exists between
+--      the two parties. Fixes "name / call / message missing on the request
+--      detail screen" — the join was returning null because the prior policy
+--      only allowed users to see their own row.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+set search_path = public;
+
+-- ── 1. accept_blood_request — one-active-commitment rule ─────────────────────
+create or replace function public.accept_blood_request(
+  p_request_id uuid,
+  p_donor_id   uuid
+)
+returns table (
+  response_id uuid,
+  status      response_status_enum,
+  message     text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_status            request_status_enum;
+  v_recipient_id      uuid;
+  v_units_needed      integer;
+  v_accepted_count    integer;
+  v_existing          response_status_enum;
+  v_resp_id           uuid;
+  v_other_commitment  uuid;
+begin
+  select br.status, br.recipient_id, br.units_needed
+    into v_status, v_recipient_id, v_units_needed
+    from public.blood_requests br
+   where br.id = p_request_id
+   for update;
+
+  if not found then
+    return query select null::uuid, null::response_status_enum, 'Request not found';
+    return;
+  end if;
+
+  if v_recipient_id = p_donor_id then
+    return query select null::uuid, null::response_status_enum, 'Cannot donate to your own request';
+    return;
+  end if;
+
+  if v_status <> 'active' then
+    return query select null::uuid, null::response_status_enum, format('Request is %s', v_status);
+    return;
+  end if;
+
+  -- Idempotency
+  select rr.status into v_existing
+    from public.request_responses rr
+   where rr.request_id = p_request_id and rr.donor_id = p_donor_id
+   for update;
+
+  if v_existing = 'accepted' then
+    select rr.id into v_resp_id from public.request_responses rr
+     where rr.request_id = p_request_id and rr.donor_id = p_donor_id;
+    return query select v_resp_id, 'accepted'::response_status_enum, 'Already accepted'::text;
+    return;
+  end if;
+
+  if v_existing = 'completed' then
+    select rr.id into v_resp_id from public.request_responses rr
+     where rr.request_id = p_request_id and rr.donor_id = p_donor_id;
+    return query select v_resp_id, 'completed'::response_status_enum, 'Already completed'::text;
+    return;
+  end if;
+
+  -- One-active-commitment guard
+  select rr.request_id
+    into v_other_commitment
+    from public.request_responses rr
+    join public.blood_requests br on br.id = rr.request_id
+   where rr.donor_id   = p_donor_id
+     and rr.status     = 'accepted'
+     and rr.request_id <> p_request_id
+     and br.status     = 'active'
+   limit 1;
+
+  if v_other_commitment is not null then
+    return query select null::uuid, null::response_status_enum,
+      'You already committed to another active request — complete or cancel that one first';
+    return;
+  end if;
+
+  -- Capacity check
+  select count(*)
+    into v_accepted_count
+    from public.request_responses rr
+   where rr.request_id = p_request_id
+     and rr.status = 'accepted';
+
+  if v_accepted_count >= v_units_needed then
+    return query select null::uuid, null::response_status_enum,
+      format('Request already has enough donors (%s of %s)', v_accepted_count, v_units_needed);
+    return;
+  end if;
+
+  insert into public.request_responses (request_id, donor_id, status)
+  values (p_request_id, p_donor_id, 'accepted')
+  on conflict (request_id, donor_id)
+  do update set status = 'accepted', updated_at = now()
+  returning id into v_resp_id;
+
+  return query select v_resp_id, 'accepted'::response_status_enum, 'OK';
+end $$;
+
+revoke all     on function public.accept_blood_request(uuid, uuid) from public;
+grant  execute on function public.accept_blood_request(uuid, uuid) to service_role;
+
+-- ── 2. profiles — mutual-commitment SELECT policy ────────────────────────────
+drop policy if exists "profiles_select_mutual_commitment" on public.profiles;
+create policy "profiles_select_mutual_commitment"
+  on public.profiles for select
+  using (
+    exists (
+      select 1
+        from public.request_responses rr
+        join public.blood_requests   br on br.id = rr.request_id
+       where rr.status in ('accepted', 'completed')
+         and (
+           (rr.donor_id     = profiles.id and br.recipient_id = auth.uid())
+           or
+           (br.recipient_id = profiles.id and rr.donor_id     = auth.uid())
+         )
+    )
+  );
+
+-- ── Verify (single-row PASS/FAIL diagnostic) ─────────────────────────────────
+select
+  case
+    when (select count(*) from pg_policies
+          where schemaname = 'public'
+            and tablename  = 'profiles'
+            and policyname = 'profiles_select_mutual_commitment') = 1
+     and (select pg_get_functiondef('public.accept_blood_request(uuid, uuid)'::regprocedure)
+            ilike '%one-active-commitment%' escape '\') is not false
+    then 'PASS · migration applied'
+    else 'FAIL · re-run the migration'
+  end as result;

--- a/migrations/2026-05-12-uber-redesign.sql
+++ b/migrations/2026-05-12-uber-redesign.sql
@@ -1,0 +1,320 @@
+-- migrations/2026-05-12-uber-redesign.sql
+-- Run once in Supabase Studio → SQL Editor.
+-- Idempotent — safe to re-run. Contains every schema delta from the
+-- 2026 Uber-style redesign pass:
+--   • Live donor-location columns on request_responses
+--   • complete_blood_donation: ambiguous-column fix + N-donors-per-N-units rule
+--   • accept_blood_request: ambiguous-column fix (table aliases)
+--   • Trigger guards: stronger service_role detection (multiple methods OR'd)
+--   • Explicit table-level grants to the authenticated + service_role roles
+--     (Supabase project defaults were missing on this project)
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 1.  Live donor-location columns on request_responses
+-- ════════════════════════════════════════════════════════════════════════════
+alter table public.request_responses
+  add column if not exists donor_lat                 double precision,
+  add column if not exists donor_lon                 double precision,
+  add column if not exists donor_location_updated_at timestamptz;
+
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'request_responses_donor_lat_range') then
+    alter table public.request_responses
+      add constraint request_responses_donor_lat_range
+      check (donor_lat is null or (donor_lat between -90 and 90));
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'request_responses_donor_lon_range') then
+    alter table public.request_responses
+      add constraint request_responses_donor_lon_range
+      check (donor_lon is null or (donor_lon between -180 and 180));
+  end if;
+end $$;
+
+create index if not exists idx_request_responses_location
+  on public.request_responses (request_id)
+  where donor_lat is not null;
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 2.  accept_blood_request RPC — table aliases on every reference
+-- ════════════════════════════════════════════════════════════════════════════
+create or replace function public.accept_blood_request(
+  p_request_id uuid,
+  p_donor_id   uuid
+)
+returns table (
+  response_id uuid,
+  status      response_status_enum,
+  message     text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_status         request_status_enum;
+  v_recipient_id   uuid;
+  v_units_needed   integer;
+  v_accepted_count integer;
+  v_existing       response_status_enum;
+  v_resp_id        uuid;
+begin
+  select br.status, br.recipient_id, br.units_needed
+    into v_status, v_recipient_id, v_units_needed
+    from public.blood_requests br
+   where br.id = p_request_id
+   for update;
+
+  if not found then
+    return query select null::uuid, null::response_status_enum, 'Request not found'::text;
+    return;
+  end if;
+
+  if v_recipient_id = p_donor_id then
+    return query select null::uuid, null::response_status_enum, 'Cannot donate to your own request'::text;
+    return;
+  end if;
+
+  if v_status <> 'active' then
+    return query select null::uuid, null::response_status_enum, format('Request is %s', v_status);
+    return;
+  end if;
+
+  select rr.status
+    into v_existing
+    from public.request_responses rr
+   where rr.request_id = p_request_id and rr.donor_id = p_donor_id
+   for update;
+
+  if v_existing = 'accepted' then
+    select rr.id into v_resp_id from public.request_responses rr
+     where rr.request_id = p_request_id and rr.donor_id = p_donor_id;
+    return query select v_resp_id, 'accepted'::response_status_enum, 'Already accepted'::text;
+    return;
+  end if;
+
+  if v_existing = 'completed' then
+    select rr.id into v_resp_id from public.request_responses rr
+     where rr.request_id = p_request_id and rr.donor_id = p_donor_id;
+    return query select v_resp_id, 'completed'::response_status_enum, 'Already completed'::text;
+    return;
+  end if;
+
+  select count(*)
+    into v_accepted_count
+    from public.request_responses rr
+   where rr.request_id = p_request_id and rr.status = 'accepted';
+
+  if v_accepted_count >= v_units_needed then
+    return query select null::uuid, null::response_status_enum,
+      format('Request already has enough donors (%s of %s)', v_accepted_count, v_units_needed);
+    return;
+  end if;
+
+  insert into public.request_responses (request_id, donor_id, status)
+  values (p_request_id, p_donor_id, 'accepted')
+  on conflict (request_id, donor_id)
+  do update set status = 'accepted', updated_at = now()
+  returning id into v_resp_id;
+
+  return query select v_resp_id, 'accepted'::response_status_enum, 'OK'::text;
+end $$;
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 3.  complete_blood_donation RPC — N-donors-per-N-units + alias-disambiguated
+-- ════════════════════════════════════════════════════════════════════════════
+create or replace function public.complete_blood_donation(
+  p_request_id uuid,
+  p_donor_id   uuid,
+  p_caller_id  uuid
+)
+returns table (
+  total_donations integer,
+  message         text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_status          request_status_enum;
+  v_recipient_id    uuid;
+  v_units_needed    integer;
+  v_completed_count integer;
+  v_resp_status     response_status_enum;
+  v_resp_id         uuid;
+  v_new_total       integer;
+begin
+  select br.status, br.recipient_id, br.units_needed
+    into v_status, v_recipient_id, v_units_needed
+    from public.blood_requests br
+   where br.id = p_request_id
+   for update;
+
+  if not found then
+    return query select null::integer, 'Request not found'::text;
+    return;
+  end if;
+
+  if v_recipient_id <> p_caller_id then
+    return query select null::integer, 'Not authorised'::text;
+    return;
+  end if;
+
+  -- Allow 'active' (normal) and 'fulfilled' (idempotent retry when partial-
+  -- multi-unit was completed and revisited).
+  if v_status not in ('active','fulfilled') then
+    return query select null::integer, format('Request already %s', v_status);
+    return;
+  end if;
+
+  select rr.id, rr.status
+    into v_resp_id, v_resp_status
+    from public.request_responses rr
+   where rr.request_id = p_request_id and rr.donor_id = p_donor_id
+   for update;
+
+  if v_resp_id is null then
+    return query select null::integer, 'Donor has not accepted this request'::text;
+    return;
+  end if;
+
+  if v_resp_status = 'completed' then
+    select p.total_donations into v_new_total from public.profiles p where p.id = p_donor_id;
+    return query select v_new_total, 'Already completed'::text;
+    return;
+  end if;
+
+  if v_resp_status <> 'accepted' then
+    return query select null::integer, format('Donor status is %s', v_resp_status);
+    return;
+  end if;
+
+  -- Flip this donor's response to completed
+  update public.request_responses set status = 'completed' where id = v_resp_id;
+
+  -- Bump donor stats. Alias to disambiguate from the OUTPUT column.
+  update public.profiles p
+     set total_donations    = p.total_donations + 1,
+         last_donation_date = now()
+   where p.id = p_donor_id;
+
+  select p.total_donations into v_new_total
+    from public.profiles p
+   where p.id = p_donor_id;
+
+  -- N donors = N units rule: request -> fulfilled only when ALL completed.
+  select count(*) into v_completed_count
+    from public.request_responses rr
+   where rr.request_id = p_request_id and rr.status = 'completed';
+
+  if v_completed_count >= v_units_needed then
+    update public.blood_requests
+       set status = 'fulfilled', donor_id = p_donor_id
+     where id = p_request_id;
+  end if;
+
+  return query select v_new_total, 'OK'::text;
+end $$;
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 4.  Trigger guards — stronger service_role detection
+-- ════════════════════════════════════════════════════════════════════════════
+create or replace function public.tg_guard_profile_privileged_writes()
+returns trigger
+language plpgsql
+as $$
+declare
+  v_is_service_role boolean;
+begin
+  v_is_service_role :=
+       current_user = 'service_role'
+    or current_role = 'service_role'
+    or coalesce(nullif(current_setting('request.jwt.claim.role', true), ''), '') = 'service_role'
+    or coalesce(nullif(current_setting('request.jwt.claims',     true), '')::jsonb->>'role', '') = 'service_role';
+  if v_is_service_role then return new; end if;
+
+  if new.total_donations    is distinct from old.total_donations    then raise exception 'total_donations is server-managed'    using errcode = '42501'; end if;
+  if new.last_donation_date is distinct from old.last_donation_date then raise exception 'last_donation_date is server-managed' using errcode = '42501'; end if;
+  if new.is_verified        is distinct from old.is_verified        then raise exception 'is_verified is server-managed'        using errcode = '42501'; end if;
+  if new.push_token         is distinct from old.push_token         then raise exception 'push_token must be set via backend /notifications/token' using errcode = '42501'; end if;
+  if new.role               is distinct from old.role               then raise exception 'role changes must go through backend (age-gated)'        using errcode = '42501'; end if;
+  return new;
+end $$;
+
+create or replace function public.tg_guard_request_updates()
+returns trigger
+language plpgsql
+as $$
+declare
+  v_is_service_role boolean;
+begin
+  v_is_service_role :=
+       current_user = 'service_role'
+    or current_role = 'service_role'
+    or coalesce(nullif(current_setting('request.jwt.claim.role', true), ''), '') = 'service_role'
+    or coalesce(nullif(current_setting('request.jwt.claims',     true), '')::jsonb->>'role', '') = 'service_role';
+  if v_is_service_role then return new; end if;
+
+  if new.recipient_id     is distinct from old.recipient_id     then raise exception 'recipient_id immutable'                using errcode = '42501'; end if;
+  if new.donor_id         is distinct from old.donor_id         then raise exception 'donor_id is server-managed'             using errcode = '42501'; end if;
+  if new.blood_group      is distinct from old.blood_group      then raise exception 'blood_group immutable after create'     using errcode = '42501'; end if;
+  if new.urgency          is distinct from old.urgency          then raise exception 'urgency is server-managed'              using errcode = '42501'; end if;
+  if new.units_needed     is distinct from old.units_needed     then raise exception 'units_needed is server-managed'         using errcode = '42501'; end if;
+  if new.hospital_name    is distinct from old.hospital_name    then raise exception 'hospital_name is server-managed'        using errcode = '42501'; end if;
+  if new.hospital_address is distinct from old.hospital_address then raise exception 'hospital_address is server-managed'     using errcode = '42501'; end if;
+  if new.latitude         is distinct from old.latitude         then raise exception 'latitude is server-managed'             using errcode = '42501'; end if;
+  if new.longitude        is distinct from old.longitude        then raise exception 'longitude is server-managed'            using errcode = '42501'; end if;
+  if new.fulfilled_at     is distinct from old.fulfilled_at     then raise exception 'fulfilled_at is server-managed'         using errcode = '42501'; end if;
+  if new.status is distinct from old.status and new.status <> 'cancelled' then
+    raise exception 'status changes other than cancelled must go through backend' using errcode = '42501';
+  end if;
+  return new;
+end $$;
+
+create or replace function public.tg_guard_message_updates()
+returns trigger
+language plpgsql
+as $$
+declare
+  v_is_service_role boolean;
+begin
+  v_is_service_role :=
+       current_user = 'service_role'
+    or current_role = 'service_role'
+    or coalesce(nullif(current_setting('request.jwt.claim.role', true), ''), '') = 'service_role'
+    or coalesce(nullif(current_setting('request.jwt.claims',     true), '')::jsonb->>'role', '') = 'service_role';
+  if v_is_service_role then return new; end if;
+
+  if new.request_id  is distinct from old.request_id  then raise exception 'request_id immutable'  using errcode = '42501'; end if;
+  if new.sender_id   is distinct from old.sender_id   then raise exception 'sender_id immutable'   using errcode = '42501'; end if;
+  if new.receiver_id is distinct from old.receiver_id then raise exception 'receiver_id immutable' using errcode = '42501'; end if;
+  if new.content     is distinct from old.content     then raise exception 'content immutable'     using errcode = '42501'; end if;
+  return new;
+end $$;
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 5.  Explicit table-level grants (Postgres checks these BEFORE RLS policies)
+-- ════════════════════════════════════════════════════════════════════════════
+grant usage on schema public to anon, authenticated, service_role;
+
+grant select, insert, update on public.profiles          to authenticated;
+grant all                    on public.profiles          to service_role;
+
+grant select, update         on public.blood_requests    to authenticated;
+grant all                    on public.blood_requests    to service_role;
+
+grant select                 on public.request_responses to authenticated;
+grant all                    on public.request_responses to service_role;
+
+grant select, insert, update on public.messages          to authenticated;
+grant all                    on public.messages          to service_role;
+
+grant select                 on public.public_profiles   to anon, authenticated;
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 6.  RPC grants (only service_role executes; clients hit them via backend)
+-- ════════════════════════════════════════════════════════════════════════════
+revoke all on function public.accept_blood_request    (uuid, uuid)       from public;
+revoke all on function public.complete_blood_donation (uuid, uuid, uuid) from public;
+grant execute on function public.accept_blood_request    (uuid, uuid)       to service_role;
+grant execute on function public.complete_blood_donation (uuid, uuid, uuid) to service_role;

--- a/mobile/app/(auth)/index.tsx
+++ b/mobile/app/(auth)/index.tsx
@@ -1,20 +1,29 @@
 // app/(auth)/index.tsx
-// Lever: cognitive-load reduction — one input on screen at a time, single
-// primary CTA, no decoration that distracts from the verb. Step indicator is
-// minimal (two dashes) — keeps the user oriented without selling progress.
+// ──────────────────────────────────────────────────────────────────────────────
+// Request-screen design language: hero zone (top ~45%) + sheet ascending over
+// it with brand accent strip, handle, spring entrance, section label, inline
+// CTA (summary row + button + footer note). One input on screen at a time
+// reduces cognitive load; the lifted sheet plus the inline CTA stack mirrors
+// the post-request flow so the visual language stays coherent edge-to-edge.
 //
 // Copy lens — Schwartz awareness:
-//   Step 1: most-aware ("What's your email?") — they came here to sign in;
+//   Step 1: most-aware ("What's your email?") — they came to sign in,
 //           no convincing needed, just a clean prompt.
 //   Step 2: problem-aware ("Check your inbox") — they know they sent it,
 //           we cue the action and reduce anxiety ("No password to remember").
+// ──────────────────────────────────────────────────────────────────────────────
 
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   KeyboardAvoidingView, Platform, Pressable, ScrollView, StyleSheet, Text, TextInput, View,
   useWindowDimensions,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as Haptics from 'expo-haptics';
+import Animated, {
+  useAnimatedStyle, useSharedValue, withSpring, withRepeat, withTiming, Easing,
+} from 'react-native-reanimated';
+import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useToast } from '@/contexts/ToastContext';
 import { supabase } from '@/utils/supabase';
@@ -22,7 +31,7 @@ import BrandMark from '@/components/BrandMark';
 import Button from '@/components/Button';
 import Input from '@/components/Input';
 import {
-  FontSize, FontWeight, LetterSpacing, Spacing, Radius, Motion,
+  FontSize, FontWeight, LetterSpacing, Spacing, Radius, Motion, Elevation,
 } from '@/constants/Typography';
 import { errorReporter } from '@/lib/errorReporter';
 
@@ -30,10 +39,41 @@ type Step = 'email' | 'otp';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+// ──────────────────────────────────────────────────────────────────────────────
+// Sheet entrance — spring from translateY 60 → 0 on mount. Same physics as
+// the Request screen's sheet so first-frame parity is exact.
+// ──────────────────────────────────────────────────────────────────────────────
+function useSheetEntrance() {
+  const ty = useSharedValue(60);
+  const op = useSharedValue(0);
+  useEffect(() => {
+    ty.value = withSpring(0, { damping: 16, stiffness: 180, mass: 0.6 });
+    op.value = withTiming(1, { duration: 280, easing: Easing.out(Easing.quad) });
+  }, [ty, op]);
+  return useAnimatedStyle(() => ({
+    transform: [{ translateY: ty.value }],
+    opacity: op.value,
+  }));
+}
+
+// Subtle breathing on the BrandMark — mirrors the Request screen's critical
+// CTA breathing pattern but very gentle (1.00 ↔ 1.03, 2.4s) so it reads as
+// "alive" rather than "alarm".
+function useBrandBreath() {
+  const s = useSharedValue(1);
+  useEffect(() => {
+    s.value = withRepeat(
+      withTiming(1.03, { duration: 2400, easing: Easing.inOut(Easing.quad) }),
+      -1, true,
+    );
+  }, [s]);
+  return useAnimatedStyle(() => ({ transform: [{ scale: s.value }] }));
+}
+
 export default function LoginScreen() {
   const { theme } = useTheme();
-  const toast = useToast();
-  const insets = useSafeAreaInsets();
+  const toast    = useToast();
+  const insets   = useSafeAreaInsets();
   const { height } = useWindowDimensions();
 
   const [step, setStep]       = useState<Step>('email');
@@ -44,18 +84,19 @@ export default function LoginScreen() {
   const [otpError, setOtpError]     = useState<string | undefined>();
   const otpRef = useRef<TextInput>(null);
 
-  const validateEmail = (value: string) => {
+  const validateEmail = useCallback((value: string) => {
     const v = value.trim().toLowerCase();
     if (!v) return 'Enter the email you want to use';
     if (!EMAIL_RE.test(v)) return "That doesn't look like a valid email";
     return undefined;
-  };
+  }, []);
 
   const sendOtp = useCallback(async () => {
     const err = validateEmail(email);
     if (err) { setEmailError(err); return; }
     setEmailError(undefined);
     setLoading(true);
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
     try {
       const { error } = await supabase.auth.signInWithOtp({
         email: email.trim().toLowerCase(),
@@ -70,13 +111,14 @@ export default function LoginScreen() {
       errorReporter.error(e, { screen: 'auth/email' });
       toast.error("Couldn't send the code", { description: e?.message ?? 'Try again in a moment' });
     } finally { setLoading(false); }
-  }, [email, toast]);
+  }, [email, toast, validateEmail]);
 
   const verifyOtp = useCallback(async () => {
     const clean = otp.trim();
     if (clean.length !== 6) { setOtpError('Enter all 6 digits'); return; }
     setOtpError(undefined);
     setLoading(true);
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
     try {
       const { error } = await supabase.auth.verifyOtp({
         email: email.trim().toLowerCase(),
@@ -84,6 +126,7 @@ export default function LoginScreen() {
         type:  'email',
       });
       if (error) throw error;
+      // Successful auth — _layout cascade handles the navigation.
     } catch (e: any) {
       errorReporter.error(e, { screen: 'auth/otp' });
       setOtpError('Code is invalid or expired');
@@ -92,34 +135,89 @@ export default function LoginScreen() {
   }, [email, otp, toast]);
 
   const goBack = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
     setStep('email');
     setOtp('');
     setOtpError(undefined);
   }, []);
+
+  const resend = useCallback(() => {
+    if (loading) return;
+    Haptics.selectionAsync().catch(() => {});
+    sendOtp();
+  }, [loading, sendOtp]);
+
+  const heroHeight   = Math.max(240, Math.round(height * 0.42));
+  const sheetEntrance = useSheetEntrance();
+  const brandBreath  = useBrandBreath();
+
+  const stepIndex = step === 'email' ? 1 : 2;
+  const stepLabel = useMemo(() => (
+    step === 'email' ? 'Step 1 of 2 · Sign in' : 'Step 2 of 2 · Verify'
+  ), [step]);
 
   return (
     <KeyboardAvoidingView
       style={[styles.root, { backgroundColor: theme.background }]}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
-      <ScrollView
-        contentContainerStyle={[styles.scroll, { minHeight: height }]}
-        keyboardShouldPersistTaps="handled"
-        showsVerticalScrollIndicator={false}
-      >
-        <View style={[styles.brandWrap, { paddingTop: insets.top + Spacing[12] }]}>
-          <BrandMark size={56} />
+      {/* ─────────────────────── HERO (DECIDE) ───────────────────────────── */}
+      <View style={[styles.hero, { height: heroHeight, backgroundColor: theme.background, paddingTop: insets.top + Spacing[6] }]}>
+        <View style={styles.heroInner}>
+          <Animated.View style={brandBreath}>
+            <BrandMark size={64} />
+          </Animated.View>
           <Text style={[styles.wordmark, { color: theme.textPrimary }]}>BLUDSTACK</Text>
           <Text style={[styles.tagline, { color: theme.textMuted }]}>
             The fastest way to find a donor
           </Text>
         </View>
 
-        <View style={[styles.formWrap, { paddingBottom: insets.bottom + Spacing[10] }]}>
+        {/* Small status pill — sits just above the sheet handle area, matches
+            the Request screen's overlay pills above the sheet. */}
+        <View style={[styles.heroPill, { backgroundColor: theme.surface, borderColor: theme.border, bottom: Spacing[10] }, Elevation.sm]}>
+          <View style={[styles.heroPillDot, { backgroundColor: theme.success }]} />
+          <Text style={[styles.heroPillText, { color: theme.textMuted }]}>
+            No password · One tap sign-in
+          </Text>
+        </View>
+      </View>
+
+      {/* ─────────────────────── SHEET (VERIFY) ──────────────────────────── */}
+      <Animated.View
+        style={[
+          styles.sheet,
+          {
+            backgroundColor: theme.surface,
+            borderTopColor: theme.border,
+            marginTop: -Spacing[5],
+          },
+          Elevation.lg,
+          sheetEntrance,
+        ]}
+      >
+        {/* Brand accent strip + handle */}
+        <View style={styles.sheetTop}>
+          <View style={[styles.accentStrip, { backgroundColor: theme.primary }]} />
+          <View style={[styles.handle, { backgroundColor: theme.borderStrong }]} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={{
+            paddingHorizontal: Spacing[5],
+            paddingBottom: insets.bottom + Spacing[8],
+            gap: Spacing[4],
+          }}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Progress bar — route-style: filled segment + remaining */}
           <View style={styles.stepIndicator}>
             <View style={[styles.stepDot, { backgroundColor: theme.primary }]} />
-            <View style={[styles.stepDot, { backgroundColor: step === 'otp' ? theme.primary : theme.border }]} />
+            <View style={[styles.stepDot, { backgroundColor: stepIndex === 2 ? theme.primary : theme.border }]} />
           </View>
+
+          <Text style={[styles.sectionLabel, { color: theme.textMuted }]}>{stepLabel}</Text>
 
           {step === 'email' ? (
             <>
@@ -142,14 +240,8 @@ export default function LoginScreen() {
                 onChangeText={t => { setEmail(t); if (emailError) setEmailError(undefined); }}
                 onSubmitEditing={sendOtp}
                 error={emailError}
+                leftIcon={<Ionicons name="mail-outline" size={18} color={theme.textMuted} />}
                 autoFocus
-              />
-              <Button
-                label="Continue"
-                onPress={sendOtp}
-                loading={loading}
-                fullWidth size="xl"
-                variant="primary"
               />
             </>
           ) : (
@@ -165,7 +257,7 @@ export default function LoginScreen() {
               </Text>
               <Input
                 ref={otpRef}
-                label="Code"
+                label="6-digit code"
                 placeholder="123456"
                 keyboardType="number-pad"
                 autoComplete="one-time-code"
@@ -180,13 +272,7 @@ export default function LoginScreen() {
                 }}
                 onSubmitEditing={verifyOtp}
                 error={otpError}
-              />
-              <Button
-                label="Verify and continue"
-                onPress={verifyOtp}
-                loading={loading}
-                fullWidth size="xl"
-                variant="primary"
+                leftIcon={<Ionicons name="keypad-outline" size={18} color={theme.textMuted} />}
               />
 
               <View style={styles.aux}>
@@ -195,8 +281,8 @@ export default function LoginScreen() {
                     Different email
                   </Text>
                 </Pressable>
-                <Pressable onPress={loading ? undefined : sendOtp} hitSlop={8} disabled={loading}>
-                  <Text style={[styles.auxLink, { color: theme.textPrimary, fontWeight: FontWeight.bold }]}>
+                <Pressable onPress={resend} hitSlop={8} disabled={loading}>
+                  <Text style={[styles.auxLink, { color: loading ? theme.textTertiary : theme.textPrimary, fontWeight: FontWeight.bold }]}>
                     Resend code
                   </Text>
                 </Pressable>
@@ -204,21 +290,57 @@ export default function LoginScreen() {
             </>
           )}
 
-          <Text style={[styles.legal, { color: theme.textTertiary }]}>
-            By continuing you agree to our Terms and acknowledge our Privacy Policy.{'\n'}
-            We never share medical info without your consent.
-          </Text>
-        </View>
-      </ScrollView>
+          {/* ── Inline CTA (ACT) — matches Request screen footer block ───── */}
+          <View style={styles.ctaInline}>
+            <View style={styles.ctaSummary}>
+              <View style={[styles.ctaSummaryDot, { backgroundColor: theme.primary }]} />
+              <Text style={[styles.ctaSummaryText, { color: theme.textPrimary }]} numberOfLines={1}>
+                <Text style={{ fontWeight: FontWeight.black, color: theme.primary }}>
+                  {step === 'email' ? 'Email' : 'Verify'}
+                </Text>
+                <Text style={{ color: theme.textMuted }}>{'  ·  '}</Text>
+                <Text>{step === 'email' ? '6-digit code by email' : 'Enter all 6 digits'}</Text>
+              </Text>
+            </View>
+
+            <Button
+              label={step === 'email' ? 'Send 6-digit code' : 'Verify and continue'}
+              onPress={step === 'email' ? sendOtp : verifyOtp}
+              loading={loading}
+              fullWidth size="xl"
+              variant="primary"
+              haptic={false}
+              icon={
+                <Ionicons
+                  name={step === 'email' ? 'send' : 'shield-checkmark'}
+                  size={18}
+                  color={theme.textOnPrimary}
+                />
+              }
+              iconPosition="left"
+            />
+
+            <Text style={[styles.ctaFooterNote, { color: theme.textTertiary }]}>
+              By continuing you agree to our Terms and acknowledge our Privacy Policy.
+              We never share medical info without your consent.
+            </Text>
+          </View>
+        </ScrollView>
+      </Animated.View>
     </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
-  root:   { flex: 1 },
-  scroll: { flexGrow: 1, justifyContent: 'space-between' },
+  root: { flex: 1 },
 
-  brandWrap: { alignItems: 'center', gap: Spacing[3], paddingBottom: Spacing[12] },
+  // ── Hero ───────────────────────────────────────────────────────────────
+  hero: {
+    position: 'relative',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  heroInner: { alignItems: 'center', gap: Spacing[3] },
   wordmark: {
     fontSize: FontSize.sm,
     fontWeight: FontWeight.black,
@@ -229,11 +351,36 @@ const styles = StyleSheet.create({
     marginTop: Spacing[1],
     letterSpacing: LetterSpacing.snug,
   },
-
-  formWrap: {
-    paddingHorizontal: Spacing[6],
-    gap: Spacing[5],
+  heroPill: {
+    position: 'absolute',
+    alignSelf: 'center',
+    flexDirection: 'row', alignItems: 'center', gap: Spacing[2],
+    paddingHorizontal: Spacing[3], paddingVertical: Spacing[2],
+    borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
   },
+  heroPillDot: { width: 6, height: 6, borderRadius: 3 },
+  heroPillText: {
+    fontSize: FontSize['2xs'],
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
+    textTransform: 'uppercase',
+  },
+
+  // ── Sheet ──────────────────────────────────────────────────────────────
+  sheet: {
+    flex: 1,
+    borderTopLeftRadius:  Radius['2xl'],
+    borderTopRightRadius: Radius['2xl'],
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  sheetTop: { alignItems: 'center', paddingTop: Spacing[2], paddingBottom: Spacing[3] },
+  accentStrip: {
+    width: 36, height: 3, borderRadius: 2, marginBottom: Spacing[1],
+    opacity: 0.9,
+  },
+  handle: { width: 44, height: 4, borderRadius: 2 },
+
+  // ── Sheet content ──────────────────────────────────────────────────────
   stepIndicator: {
     flexDirection: 'row',
     gap: Spacing[2],
@@ -243,6 +390,13 @@ const styles = StyleSheet.create({
     flex: 1,
     height: 3,
     borderRadius: Radius.pill,
+  },
+  sectionLabel: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
+    textTransform: 'uppercase',
+    marginLeft: Spacing[2],
   },
   title: {
     fontSize: FontSize['2xl'],
@@ -258,7 +412,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     paddingHorizontal: Spacing[2],
-    marginTop: Spacing[2],
+    marginTop: Spacing[1],
   },
   auxLink: {
     fontSize: FontSize.sm,
@@ -266,10 +420,29 @@ const styles = StyleSheet.create({
     letterSpacing: LetterSpacing.snug,
   },
 
-  legal: {
+  // ── In-form CTA ────────────────────────────────────────────────────────
+  ctaInline: {
+    marginTop: Spacing[2],
+    gap: Spacing[3],
+  },
+  ctaSummary: {
+    flexDirection: 'row', alignItems: 'center',
+    gap: Spacing[2],
+    paddingHorizontal: Spacing[1],
+  },
+  ctaSummaryDot: { width: 8, height: 8, borderRadius: 4 },
+  ctaSummaryText: {
+    flex: 1,
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.bold,
+    letterSpacing: LetterSpacing.snug,
+  },
+  ctaFooterNote: {
     fontSize: FontSize.xs,
+    fontWeight: FontWeight.medium,
+    letterSpacing: LetterSpacing.snug,
     textAlign: 'center',
-    lineHeight: FontSize.xs * 1.6,
-    marginTop: Spacing[4],
+    paddingHorizontal: Spacing[4],
+    lineHeight: FontSize.xs * 1.5,
   },
 });

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -32,11 +32,20 @@ type TabDef = {
   cta?: boolean;
 };
 
+// Visibility rules:
+//   • 'all'        → every authenticated user sees it.
+//   • 'donor'      → donor + both.
+//   • 'recipient'  → recipient + both.
+//
+// `my-requests` is intentionally 'all' even though donor-only is rare here:
+// the Request tab is 'all', so any user who can POST a request must be able
+// to see + manage what they posted. Hiding my-requests from donors created
+// a state where a donor could post and then never reach their post again.
 const ALL_TABS: readonly TabDef[] = [
   { name: 'index',        label: 'Home',     icon: 'home-outline',    iconActive: 'home',          role: 'donor' },
   { name: 'request',      label: 'Request',  icon: 'add-circle',      iconActive: 'add-circle',    role: 'all', cta: true },
   { name: 'donors',       label: 'Find',     icon: 'search-outline',  iconActive: 'search',        role: 'donor' },
-  { name: 'my-requests',  label: 'Requests', icon: 'list-outline',    iconActive: 'list',          role: 'recipient' },
+  { name: 'my-requests',  label: 'Requests', icon: 'list-outline',    iconActive: 'list',          role: 'all' },
   { name: 'history',      label: 'History',  icon: 'heart-outline',   iconActive: 'heart',         role: 'donor' },
   { name: 'profile',      label: 'Account',  icon: 'person-outline',  iconActive: 'person',        role: 'all' },
 ] as const;

--- a/mobile/app/(tabs)/donors.tsx
+++ b/mobile/app/(tabs)/donors.tsx
@@ -1,32 +1,45 @@
 // app/(tabs)/donors.tsx
-import React, { useState, useCallback, useMemo } from 'react';
+// Lever: discovery, no nudge — exploration mode for donors. Pill filters,
+// map / list toggle, theme-tokenised throughout. Self-posted requests are
+// already excluded server-side AND client-side; this screen always shows
+// requests other people have posted.
+
+import React, { useCallback, useMemo, useState } from 'react';
 import {
-  View, Text, StyleSheet, TouchableOpacity,
-  FlatList, useWindowDimensions,
+  View, Text, StyleSheet, Pressable, useWindowDimensions, RefreshControl,
 } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
 import MapView, { Marker, Circle, PROVIDER_DEFAULT } from 'react-native-maps';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/contexts/ThemeContext';
-import { useAuth } from '@/contexts/AuthContext';
 import { useLocation } from '@/hooks/useLocation';
-import { useNearbyRequests, BloodRequest } from '@/hooks/useRequests';
+import { useNearbyRequests, type BloodRequest } from '@/hooks/useRequests';
 import RequestCard from '@/components/RequestCard';
-import BloodGroupBadge from '@/components/BloodGroupBadge';
 import SelectSheet from '@/components/SelectSheet';
 import EmptyState from '@/components/EmptyState';
-import { FontSize, FontWeight, Spacing, Radius, LetterSpacing } from '@/constants/Typography';
-import { BLOOD_GROUPS, URGENCY_CONFIG, UrgencyLevel } from '@/constants/BloodData';
-import { getBloodGroupColor } from '@/utils/helpers';
+import {
+  FontSize, FontWeight, Spacing, Radius, LetterSpacing,
+  TAB_BAR_BOTTOM_INSET, Elevation,
+} from '@/constants/Typography';
+import { BLOOD_GROUPS, type UrgencyLevel } from '@/constants/BloodData';
 import { deltaFromKm } from '@/utils/geo';
 
 type ViewMode = 'list' | 'map';
 
+const URGENCY_LABEL: Record<UrgencyLevel | 'All', string> = {
+  All:      'All urgency',
+  critical: 'Critical',
+  urgent:   'Urgent',
+  standard: 'Standard',
+};
+
 export default function DonorsScreen() {
   const { theme, isDark } = useTheme();
-  const { profile } = useAuth();
-  const router   = useRouter();
-  const insets   = useSafeAreaInsets();
+  const router  = useRouter();
+  const insets  = useSafeAreaInsets();
   const { height } = useWindowDimensions();
 
   const { location, refreshLocation } = useLocation(true);
@@ -36,8 +49,8 @@ export default function DonorsScreen() {
   );
 
   const [viewMode, setViewMode]             = useState<ViewMode>('list');
-  const [filterBlood, setFilterBlood]       = useState('All');
-  const [filterUrgency, setFilterUrgency]   = useState('All');
+  const [filterBlood, setFilterBlood]       = useState<string>('All');
+  const [filterUrgency, setFilterUrgency]   = useState<string>('All');
   const [bloodVisible, setBloodVisible]     = useState(false);
   const [urgencyVisible, setUrgencyVisible] = useState(false);
 
@@ -48,92 +61,144 @@ export default function DonorsScreen() {
   }), [requests, filterBlood, filterUrgency]);
 
   const mapRegion = useMemo(() => location ? {
-    latitude: location.latitude, longitude: location.longitude,
-    latitudeDelta: deltaFromKm(25), longitudeDelta: deltaFromKm(25),
+    latitude:       location.latitude,
+    longitude:      location.longitude,
+    latitudeDelta:  deltaFromKm(25),
+    longitudeDelta: deltaFromKm(25),
   } : undefined, [location]);
+
+  const onCardPress = useCallback((r: BloodRequest) => {
+    Haptics.selectionAsync().catch(() => {});
+    router.push(`/request/${r.id}` as any);
+  }, [router]);
+
+  const onModeChange = useCallback((m: ViewMode) => {
+    Haptics.selectionAsync().catch(() => {});
+    setViewMode(m);
+  }, []);
+
+  const openBlood   = useCallback(() => { Haptics.selectionAsync().catch(() => {}); setBloodVisible(true); }, []);
+  const openUrgency = useCallback(() => { Haptics.selectionAsync().catch(() => {}); setUrgencyVisible(true); }, []);
 
   const renderItem = useCallback(({ item }: { item: BloodRequest }) => (
     <RequestCard
       request={item}
-      userLat={location?.latitude}
-      userLon={location?.longitude}
-      onPress={r => router.push(`/request/${r.id}`)}
+      userLat={location?.latitude ?? null}
+      userLon={location?.longitude ?? null}
+      onPress={onCardPress}
     />
-  ), [location, router]);
+  ), [location?.latitude, location?.longitude, onCardPress]);
 
   const keyExtractor = useCallback((item: BloodRequest) => item.id, []);
 
-  const bloodOptions = [
-    { label: 'All Groups', value: 'All' },
+  const clearFilters = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    setFilterBlood('All');
+    setFilterUrgency('All');
+  }, []);
+
+  const bloodOptions = useMemo(() => [
+    { label: 'All groups', value: 'All' },
     ...BLOOD_GROUPS.map(bg => ({ label: bg, value: bg })),
-  ];
-  const urgencyOptions = [
-    { label: 'All Urgency', value: 'All' },
-    { label: 'Critical', value: 'critical', description: 'Needed within 30 min' },
-    { label: 'Urgent',   value: 'urgent',   description: 'Needed within 2 hours' },
-    { label: 'Standard', value: 'standard', description: 'Scheduled donation' },
-  ];
+  ], []);
+
+  const urgencyOptions = useMemo(() => [
+    { label: 'All urgency', value: 'All' },
+    { label: 'Critical',    value: 'critical', description: 'Within 30 minutes' },
+    { label: 'Urgent',      value: 'urgent',   description: 'Within 2 hours' },
+    { label: 'Standard',    value: 'standard', description: 'Scheduled' },
+  ], []);
 
   const hasFilters = filterBlood !== 'All' || filterUrgency !== 'All';
 
   return (
     <View style={[styles.root, { backgroundColor: theme.background }]}>
-
-      {/* ── Top bar ── */}
-      <View style={[styles.topBar, { paddingTop: insets.top + Spacing[4], backgroundColor: theme.surface, borderBottomColor: theme.border }]}>
-        <View style={styles.topRow}>
-          <View>
-            <Text style={[styles.pageTitle, { color: theme.textPrimary }]}>Find Requests</Text>
-            <Text style={[styles.pageSubtitle, { color: theme.textMuted }]}>
+      {/* Header */}
+      <View
+        style={[
+          styles.header,
+          {
+            paddingTop: insets.top + Spacing[4],
+            backgroundColor: theme.surface,
+            borderBottomColor: theme.border,
+          },
+        ]}
+      >
+        <View style={styles.headerRow}>
+          <View style={{ flex: 1 }}>
+            <Text style={[styles.sectionLabel, { color: theme.textMuted }]}>Discover · Nearby</Text>
+            <Text style={[styles.title, { color: theme.textPrimary }]}>Find requests</Text>
+            <Text style={[styles.subtitle, { color: theme.textMuted }]}>
               {filtered.length} active near you
             </Text>
           </View>
-          {/* Map / List toggle */}
-          <View style={[styles.toggleWrap, { backgroundColor: theme.cardElevated }]}>
-            {(['list', 'map'] as ViewMode[]).map(m => (
-              <TouchableOpacity
-                key={m}
-                onPress={() => setViewMode(m)}
-                style={[styles.toggleBtn, viewMode === m && { backgroundColor: theme.textPrimary }]}
-                activeOpacity={0.7}
-              >
-                <Text style={[styles.toggleLabel, { color: viewMode === m ? theme.textInverse : theme.textMuted }]}>
-                  {m === 'list' ? '≡ List' : '◎ Map'}
-                </Text>
-              </TouchableOpacity>
-            ))}
+          <View style={[styles.toggleWrap, { backgroundColor: theme.cardElevated, borderColor: theme.border }]}>
+            {(['list', 'map'] as ViewMode[]).map(m => {
+              const active = viewMode === m;
+              return (
+                <Pressable
+                  key={m}
+                  onPress={() => onModeChange(m)}
+                  style={[
+                    styles.toggleBtn,
+                    active && { backgroundColor: theme.textPrimary },
+                  ]}
+                  accessibilityRole="tab"
+                  accessibilityState={{ selected: active }}
+                  accessibilityLabel={m}
+                >
+                  <Ionicons
+                    name={m === 'list' ? 'list' : 'map'}
+                    size={14}
+                    color={active ? theme.textInverse : theme.textMuted}
+                  />
+                  <Text style={[
+                    styles.toggleLabel,
+                    { color: active ? theme.textInverse : theme.textMuted },
+                  ]}>
+                    {m === 'list' ? 'List' : 'Map'}
+                  </Text>
+                </Pressable>
+              );
+            })}
           </View>
         </View>
 
-        {/* Filter chips */}
         <View style={styles.filters}>
           <FilterChip
-            label={filterBlood === 'All' ? 'Blood Group' : filterBlood}
+            iconName="water"
+            label={filterBlood === 'All' ? 'Blood group' : filterBlood}
             active={filterBlood !== 'All'}
-            onPress={() => setBloodVisible(true)}
+            onPress={openBlood}
             theme={theme}
           />
           <FilterChip
-            label={filterUrgency === 'All' ? 'Urgency' : URGENCY_CONFIG[filterUrgency as UrgencyLevel].label}
+            iconName="flash-outline"
+            label={URGENCY_LABEL[(filterUrgency as UrgencyLevel | 'All')]}
             active={filterUrgency !== 'All'}
-            onPress={() => setUrgencyVisible(true)}
+            onPress={openUrgency}
             theme={theme}
           />
           {hasFilters && (
-            <TouchableOpacity
-              onPress={() => { setFilterBlood('All'); setFilterUrgency('All'); }}
-              style={[styles.clearChip, { borderColor: theme.border }]}
-              activeOpacity={0.7}
+            <Pressable
+              onPress={clearFilters}
+              style={({ pressed }) => [
+                styles.clearChip,
+                { borderColor: theme.border, opacity: pressed ? 0.85 : 1 },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Clear filters"
             >
-              <Text style={[styles.clearLabel, { color: theme.textMuted }]}>✕ Clear</Text>
-            </TouchableOpacity>
+              <Ionicons name="close" size={14} color={theme.textMuted} />
+              <Text style={[styles.clearLabel, { color: theme.textMuted }]}>Clear</Text>
+            </Pressable>
           )}
         </View>
       </View>
 
-      {/* ── Map view ── */}
+      {/* Map */}
       {viewMode === 'map' && location && (
-        <View style={{ height: height * 0.45 }}>
+        <View style={[styles.mapWrap, { height: height * 0.42 }]}>
           <MapView
             style={StyleSheet.absoluteFill}
             provider={PROVIDER_DEFAULT}
@@ -147,7 +212,7 @@ export default function DonorsScreen() {
                 key={km}
                 center={{ latitude: location.latitude, longitude: location.longitude }}
                 radius={km * 1000}
-                strokeColor={`${theme.textSecondary}30`}
+                strokeColor={theme.border}
                 fillColor="transparent"
                 strokeWidth={1}
               />
@@ -156,10 +221,12 @@ export default function DonorsScreen() {
               <Marker
                 key={req.id}
                 coordinate={{ latitude: req.latitude, longitude: req.longitude }}
-                onPress={() => router.push(`/request/${req.id}`)}
+                onPress={() => onCardPress(req)}
               >
-                <View style={[styles.mapMarker, { backgroundColor: getBloodGroupColor(req.blood_group) }]}>
-                  <Text style={styles.mapMarkerText}>{req.blood_group}</Text>
+                <View style={[styles.mapPin, { backgroundColor: theme.primary }]}>
+                  <Text style={[styles.mapPinText, { color: theme.textOnPrimary }]}>
+                    {req.blood_group}
+                  </Text>
                 </View>
               </Marker>
             ))}
@@ -167,80 +234,157 @@ export default function DonorsScreen() {
         </View>
       )}
 
-      {/* ── List ── */}
-      <FlatList
+      {/* List */}
+      <FlashList
         data={filtered}
         keyExtractor={keyExtractor}
         renderItem={renderItem}
-        contentContainerStyle={[styles.list, { paddingBottom: insets.bottom + Spacing[12] }]}
+        getItemType={() => 'request'}
+        contentContainerStyle={{
+          paddingHorizontal: Spacing[5],
+          paddingTop: Spacing[5],
+          paddingBottom: TAB_BAR_BOTTOM_INSET + Spacing[4],
+        }}
         showsVerticalScrollIndicator={false}
-        onRefresh={refetch}
-        refreshing={loading}
+        refreshControl={
+          <RefreshControl
+            refreshing={false}
+            onRefresh={refetch}
+            tintColor="transparent"
+            colors={['transparent']}
+            progressBackgroundColor="transparent"
+            progressViewOffset={-1000}
+          />
+        }
         ListEmptyComponent={
           <EmptyState
-            icon="🔍"
-            title="No requests match"
-            description="Try different filters or check back soon."
-            actionLabel={hasFilters ? 'Clear filters' : undefined}
-            onAction={hasFilters ? () => { setFilterBlood('All'); setFilterUrgency('All'); } : undefined}
+            iconName={hasFilters ? 'filter-outline' : 'search'}
+            title={hasFilters ? 'No requests match those filters' : 'No requests near you'}
+            description={
+              hasFilters
+                ? 'Widen the search or clear the filters to see more.'
+                : "We'll ping you the moment a compatible request lands."
+            }
+            actionLabel={hasFilters ? 'Reset filters' : undefined}
+            onAction={hasFilters ? clearFilters : undefined}
           />
         }
       />
 
       <SelectSheet
         visible={bloodVisible}
-        title="Filter by Blood Group"
+        title="Filter by blood group"
         options={bloodOptions}
-        selected={filterBlood}
-        onSelect={setFilterBlood}
+        value={filterBlood}
+        onSelect={(v: string) => setFilterBlood(v)}
         onClose={() => setBloodVisible(false)}
       />
       <SelectSheet
         visible={urgencyVisible}
-        title="Filter by Urgency"
+        title="Filter by urgency"
         options={urgencyOptions}
-        selected={filterUrgency}
-        onSelect={setFilterUrgency}
+        value={filterUrgency}
+        onSelect={(v: string) => setFilterUrgency(v)}
         onClose={() => setUrgencyVisible(false)}
       />
     </View>
   );
 }
 
-function FilterChip({ label, active, onPress, theme }: {
+const FilterChip = React.memo(function FilterChip({
+  iconName, label, active, onPress, theme,
+}: {
+  iconName: keyof typeof Ionicons.glyphMap;
   label: string; active: boolean; onPress: () => void; theme: any;
 }) {
   return (
-    <TouchableOpacity
+    <Pressable
       onPress={onPress}
-      activeOpacity={0.7}
-      style={[styles.chip, {
-        backgroundColor: active ? theme.textPrimary : theme.card,
-        borderColor:     active ? theme.textPrimary : theme.border,
-      }]}
+      style={({ pressed }) => [
+        styles.chip,
+        {
+          backgroundColor: active ? theme.textPrimary : theme.cardElevated,
+          borderColor:     active ? theme.textPrimary : theme.border,
+          opacity: pressed ? 0.92 : 1,
+        },
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={label}
     >
-      <Text style={[styles.chipLabel, { color: active ? theme.textInverse : theme.textSecondary }]}>
-        {label}
-      </Text>
-    </TouchableOpacity>
+      <Ionicons
+        name={iconName}
+        size={14}
+        color={active ? theme.textInverse : theme.textPrimary}
+      />
+      <Text style={[
+        styles.chipLabel,
+        { color: active ? theme.textInverse : theme.textPrimary },
+      ]}>{label}</Text>
+    </Pressable>
   );
-}
+});
 
 const styles = StyleSheet.create({
-  root:         { flex: 1 },
-  topBar:       { paddingHorizontal: Spacing[5], paddingBottom: Spacing[3], borderBottomWidth: StyleSheet.hairlineWidth },
-  topRow:       { flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: Spacing[3] },
-  pageTitle:    { fontSize: FontSize.xl, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.tight },
-  pageSubtitle: { fontSize: FontSize.xs, marginTop: 2 },
-  toggleWrap:   { flexDirection: 'row', borderRadius: Radius.xs, overflow: 'hidden', padding: 2 },
-  toggleBtn:    { paddingHorizontal: Spacing[3], paddingVertical: Spacing[1], borderRadius: Radius.xs - 2 },
-  toggleLabel:  { fontSize: FontSize.xs, fontWeight: FontWeight.bold },
-  filters:      { flexDirection: 'row', gap: Spacing[2], flexWrap: 'wrap' },
-  chip:         { paddingHorizontal: Spacing[3], paddingVertical: Spacing[1], borderRadius: Radius.full, borderWidth: StyleSheet.hairlineWidth },
-  chipLabel:    { fontSize: FontSize.xs, fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.wide },
-  clearChip:    { paddingHorizontal: Spacing[3], paddingVertical: Spacing[1], borderRadius: Radius.full, borderWidth: StyleSheet.hairlineWidth },
-  clearLabel:   { fontSize: FontSize.xs, fontWeight: FontWeight.medium },
-  list:         { padding: Spacing[5] },
-  mapMarker:    { paddingHorizontal: Spacing[2], paddingVertical: 3, borderRadius: Radius.xs },
-  mapMarkerText:{ color: '#fff', fontSize: FontSize.xs, fontWeight: FontWeight.black },
+  root: { flex: 1 },
+  header: {
+    paddingHorizontal: Spacing[5],
+    paddingBottom: Spacing[4],
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: Spacing[4],
+  },
+  headerRow: { flexDirection: 'row', alignItems: 'center', gap: Spacing[3] },
+  sectionLabel: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
+    textTransform: 'uppercase',
+    marginBottom: Spacing[1],
+  },
+  title: {
+    fontSize: FontSize['2xl'], fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.tighter,
+  },
+  subtitle: { fontSize: FontSize.xs, marginTop: 2, fontWeight: FontWeight.semibold },
+
+  toggleWrap: {
+    flexDirection: 'row',
+    borderRadius: Radius.pill,
+    padding: 3,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  toggleBtn: {
+    flexDirection: 'row', alignItems: 'center', gap: 4,
+    paddingHorizontal: Spacing[3], paddingVertical: Spacing[1],
+    borderRadius: Radius.pill,
+  },
+  toggleLabel: { fontSize: FontSize.xs, fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.snug },
+
+  filters: { flexDirection: 'row', gap: Spacing[2], flexWrap: 'wrap' },
+  chip: {
+    flexDirection: 'row', alignItems: 'center', gap: 4,
+    paddingHorizontal: Spacing[3], paddingVertical: Spacing[2],
+    borderRadius: Radius.pill, borderWidth: 1.5,
+  },
+  chipLabel: { fontSize: FontSize.xs, fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.snug },
+  clearChip: {
+    flexDirection: 'row', alignItems: 'center', gap: 4,
+    paddingHorizontal: Spacing[3], paddingVertical: Spacing[2],
+    borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
+  },
+  clearLabel: { fontSize: FontSize.xs, fontWeight: FontWeight.semibold },
+
+  mapWrap: {
+    marginHorizontal: Spacing[4],
+    marginTop: Spacing[4],
+    borderRadius: Radius.xl,
+    overflow: 'hidden',
+  },
+  mapPin: {
+    paddingHorizontal: Spacing[2], paddingVertical: 4,
+    borderRadius: Radius.pill,
+  },
+  mapPinText: {
+    fontSize: FontSize.xs, fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.snug,
+  },
 });

--- a/mobile/app/(tabs)/history.tsx
+++ b/mobile/app/(tabs)/history.tsx
@@ -1,76 +1,62 @@
 // app/(tabs)/history.tsx
-// DONOR HISTORY — Full donation record, impact stats, timeline.
-//
-// Issue #6: History page shows the history of donations made by the user.
-// Issue #9: Only shown to donors (role = 'donor' | 'both')
-// Issue #16: SafeAreaView for iOS & Android
+// Lever: identity reinforcement + peak-end. The donor sees their full record
+// of saved lives in a clean timeline; the hero card affirms identity ("X
+// donations · X lives helped") and the eligibility pill tells them when they
+// can give again.
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-    View, Text, StyleSheet, FlatList,
-    TouchableOpacity, RefreshControl,
+  View, Text, StyleSheet, Pressable, RefreshControl,
 } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useAuth, canDonateByAge } from '@/contexts/AuthContext';
 import { supabase } from '@/utils/supabase';
 import BloodGroupBadge from '@/components/BloodGroupBadge';
 import EmptyState from '@/components/EmptyState';
-import PressableScale from '@/components/PressableScale';
 import {
-    FontSize, FontWeight, Spacing, Radius,
-    LetterSpacing, TAB_BAR_BOTTOM_INSET,
+  FontSize, FontWeight, Spacing, Radius, LetterSpacing,
+  TAB_BAR_BOTTOM_INSET, Elevation,
 } from '@/constants/Typography';
 import { timeAgo, formatDate, canDonateAgain } from '@/utils/helpers';
 
 interface DonationRecord {
+  id: string;
+  status: 'accepted' | 'completed' | 'pending' | 'declined';
+  created_at: string;
+  blood_request: {
     id: string;
-    status: 'accepted' | 'completed' | 'pending' | 'declined';
+    blood_group: string;
+    urgency: 'critical' | 'urgent' | 'standard';
+    hospital_name: string;
+    hospital_address: string;
+    status: string;
     created_at: string;
-    blood_request: {
-        id: string;
-        blood_group: string;
-        urgency: string;
-        hospital_name: string;
-        hospital_address: string;
-        status: string;
-        created_at: string;
-    } | null;
+  } | null;
 }
 
-const URGENCY_COLOR: Record<string, string> = {
-    critical: '#E8002D',
-    urgent: '#F5A623',
-    standard: '#00A651',
-};
-
-const STATUS_CFG: Record<string, { label: string; color: string }> = {
-    completed: { label: 'Donated ✓', color: '#00A651' },
-    accepted: { label: 'En Route', color: '#2196F3' },
-    pending: { label: 'Pending', color: '#F5A623' },
-    declined: { label: 'Declined', color: '#9B9B9B' },
-};
-
 export default function HistoryScreen() {
-    const { theme } = useTheme();
-    const { profile } = useAuth();
-    const router = useRouter();
+  const { theme } = useTheme();
+  const { profile } = useAuth();
+  const router = useRouter();
 
-    const [records, setRecords] = useState<DonationRecord[]>([]);
-    const [loading, setLoading] = useState(true);
+  const [records, setRecords] = useState<DonationRecord[]>([]);
+  const [loading, setLoading] = useState(true);
 
-    const { canDonate, daysLeft } = canDonateAgain(profile?.last_donation_date ?? null);
-    const ageOk = canDonateByAge(profile?.date_of_birth ?? null);
+  const { canDonate, daysLeft } = canDonateAgain(profile?.last_donation_date ?? null);
+  const ageOk = canDonateByAge(profile?.date_of_birth ?? null);
 
-    const fetchHistory = useCallback(async () => {
-        if (!profile?.id) return;
-        setLoading(true);
-        try {
-            const { data, error } = await supabase
-                .from('request_responses')
-                .select(`
+  const fetchHistory = useCallback(async () => {
+    if (!profile?.id) return;
+    setLoading(true);
+    try {
+      const { data, error } = await supabase
+        .from('request_responses')
+        .select(`
           id, status, created_at,
           blood_request:blood_requests!request_id (
             id, blood_group, urgency,
@@ -78,208 +64,303 @@ export default function HistoryScreen() {
             status, created_at
           )
         `)
-                .eq('donor_id', profile.id)
-                .order('created_at', { ascending: false });
-            if (error) throw error;
-            setRecords((data as any[]) ?? []);
-        } catch (e: any) {
-            console.warn('[history]', e.message);
-        } finally {
-            setLoading(false);
+        .eq('donor_id', profile.id)
+        .order('created_at', { ascending: false });
+      if (error) throw error;
+      setRecords((data as any[]) ?? []);
+    } catch (e: any) {
+      console.warn('[history]', e?.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [profile?.id]);
+
+  useEffect(() => { fetchHistory(); }, [fetchHistory]);
+
+  const completedCount = useMemo(
+    () => records.filter(r => r.status === 'completed').length,
+    [records],
+  );
+  // 1 donor = 1 unit = 1 life.
+  const livesHelped = completedCount;
+
+  const onRowPress = useCallback((id: string) => {
+    Haptics.selectionAsync().catch(() => {});
+    router.push(`/request/${id}` as any);
+  }, [router]);
+
+  const goFindRequests = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    router.push('/(tabs)/donors' as any);
+  }, [router]);
+
+  const renderItem = useCallback(({ item }: { item: DonationRecord }) => {
+    const req = item.blood_request;
+    if (!req) return null;
+
+    const statusMeta = (() => {
+      switch (item.status) {
+        case 'completed': return { label: 'Donated',  iconName: 'checkmark-circle' as const, tone: theme.success };
+        case 'accepted':  return { label: 'En route', iconName: 'navigate'         as const, tone: theme.primary };
+        case 'pending':   return { label: 'Pending',  iconName: 'time-outline'     as const, tone: theme.warning };
+        case 'declined':  return { label: 'Declined', iconName: 'close-circle'     as const, tone: theme.textMuted };
+        default: return { label: item.status, iconName: 'ellipsis-horizontal' as const, tone: theme.textMuted };
+      }
+    })();
+
+    const urgencyTone =
+      req.urgency === 'critical' ? theme.danger
+      : req.urgency === 'urgent'   ? theme.warning
+      :                              theme.success;
+
+    return (
+      <Pressable
+        onPress={() => onRowPress(req.id)}
+        style={({ pressed }) => [
+          styles.row,
+          {
+            backgroundColor: theme.card,
+            borderColor: theme.border,
+            opacity: pressed ? 0.96 : 1,
+          },
+          Elevation.xs,
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={`${statusMeta.label} at ${req.hospital_name}`}
+      >
+        <View style={[styles.stripe, { backgroundColor: urgencyTone }]} />
+        <View style={styles.rowBody}>
+          <View style={styles.rowTop}>
+            <BloodGroupBadge bloodGroup={req.blood_group} size="md" variant="soft" />
+            <View style={styles.rowMeta}>
+              <Text style={[styles.hospital, { color: theme.textPrimary }]} numberOfLines={1}>
+                {req.hospital_name}
+              </Text>
+              <Text style={[styles.addr, { color: theme.textMuted }]} numberOfLines={1}>
+                {req.hospital_address}
+              </Text>
+              <Text style={[styles.time, { color: theme.textTertiary }]}>{timeAgo(item.created_at)}</Text>
+            </View>
+            <View style={[styles.statusPill, { backgroundColor: statusMeta.tone + '1F', borderColor: statusMeta.tone }]}>
+              <Ionicons name={statusMeta.iconName} size={12} color={statusMeta.tone} />
+              <Text style={[styles.statusText, { color: statusMeta.tone }]}>{statusMeta.label}</Text>
+            </View>
+          </View>
+        </View>
+      </Pressable>
+    );
+  }, [theme, onRowPress]);
+
+  const keyExtractor = useCallback((item: DonationRecord) => item.id, []);
+
+  const Header = useMemo(() => (
+    <View style={{ gap: Spacing[4], paddingTop: Spacing[4] }}>
+      {/* Hero stats */}
+      <View style={[styles.statsCard, { backgroundColor: theme.card, borderColor: theme.border }, Elevation.xs]}>
+        <StatCell value={String(profile?.total_donations ?? 0)} label="Donations"   color={theme.primary}   theme={theme} />
+        <View style={[styles.statDiv, { backgroundColor: theme.divider }]} />
+        <StatCell value={String(livesHelped)}                    label="Lives helped" color={theme.success}   theme={theme} />
+        <View style={[styles.statDiv, { backgroundColor: theme.divider }]} />
+        <StatCell
+          value={profile?.last_donation_date ? formatDate(profile.last_donation_date) : '—'}
+          label="Last donated"
+          color={theme.textPrimary}
+          theme={theme}
+          small
+        />
+      </View>
+
+      {/* Eligibility */}
+      <View
+        style={[
+          styles.eligibilityCard,
+          {
+            backgroundColor: canDonate && ageOk ? theme.successSoft : theme.warningSoft,
+            borderColor:     canDonate && ageOk ? theme.success     : theme.warning,
+          },
+        ]}
+      >
+        <View
+          style={[
+            styles.eligIconWrap,
+            { backgroundColor: canDonate && ageOk ? theme.success : theme.warning },
+          ]}
+        >
+          <Ionicons
+            name={canDonate && ageOk ? 'checkmark' : 'time'}
+            size={18}
+            color={theme.textOnPrimary}
+          />
+        </View>
+        <View style={{ flex: 1 }}>
+          <Text style={[styles.eligTitle, { color: canDonate && ageOk ? theme.success : theme.warning }]}>
+            {!ageOk
+              ? 'Donors must be 18 or older'
+              : canDonate
+                ? "You're eligible to donate now"
+                : `Eligible again in ${daysLeft} day${daysLeft === 1 ? '' : 's'}`}
+          </Text>
+          <Text style={[styles.eligSub, { color: theme.textMuted }]}>
+            {!ageOk
+              ? 'Update your date of birth in profile if this is wrong.'
+              : canDonate
+                ? 'Browse nearby requests to help someone today.'
+                : '90-day cooldown protects your health.'}
+          </Text>
+        </View>
+      </View>
+
+      <Text style={[styles.sectionLabel, { color: theme.textMuted }]}>Timeline · Your donations</Text>
+    </View>
+  ), [theme, profile?.total_donations, profile?.last_donation_date, livesHelped, canDonate, ageOk, daysLeft]);
+
+  return (
+    <SafeAreaView style={[styles.root, { backgroundColor: theme.background }]} edges={['top']}>
+      <View style={[styles.header, { borderBottomColor: theme.border }]}>
+        <Text style={[styles.sectionLabel, { color: theme.textMuted }]}>Impact · Lives helped</Text>
+        <Text style={[styles.title, { color: theme.textPrimary }]}>Your impact</Text>
+        <Text style={[styles.subtitle, { color: theme.textMuted }]}>Every donation, every life helped.</Text>
+      </View>
+
+      <FlashList
+        data={records}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        ListHeaderComponent={Header}
+        getItemType={() => 'history'}
+        contentContainerStyle={{
+          paddingHorizontal: Spacing[5],
+          paddingBottom: TAB_BAR_BOTTOM_INSET + Spacing[4],
+        }}
+        ItemSeparatorComponent={() => <View style={{ height: Spacing[3] }} />}
+        refreshControl={
+          <RefreshControl
+            refreshing={false}
+            onRefresh={fetchHistory}
+            tintColor="transparent"
+            colors={['transparent']}
+            progressBackgroundColor="transparent"
+            progressViewOffset={-1000}
+          />
         }
-    }, [profile?.id]);
-
-    useEffect(() => { fetchHistory(); }, [fetchHistory]);
-
-    const completedCount = records.filter(r => r.status === 'completed').length;
-    const livesHelped = completedCount * 3;
-
-    const renderItem = useCallback(({ item }: { item: DonationRecord }) => {
-        const req = item.blood_request;
-        if (!req) return null;
-        const st = STATUS_CFG[item.status] ?? { label: item.status, color: theme.textMuted };
-        const uc = URGENCY_COLOR[req.urgency] ?? '#E8002D';
-        return (
-            <TouchableOpacity onPress={() => router.push(`/request/${req.id}`)} activeOpacity={0.75}>
-                <View style={[styles.row, { backgroundColor: theme.card, borderColor: theme.border }]}>
-                    {/* Left urgency stripe */}
-                    <View style={[styles.stripe, { backgroundColor: uc }]} />
-                    <View style={styles.rowBody}>
-                        <View style={styles.rowTop}>
-                            <BloodGroupBadge bloodGroup={req.blood_group} size="md" inverted />
-                            <View style={styles.rowMeta}>
-                                <Text style={[styles.hospital, { color: theme.textPrimary }]} numberOfLines={1}>
-                                    {req.hospital_name}
-                                </Text>
-                                <Text style={[styles.addr, { color: theme.textSecondary }]} numberOfLines={1}>
-                                    {req.hospital_address}
-                                </Text>
-                                <Text style={[styles.time, { color: theme.textMuted }]}>
-                                    {timeAgo(item.created_at)}
-                                </Text>
-                            </View>
-                            <View style={[styles.statusPill, { backgroundColor: `${st.color}18`, borderColor: `${st.color}40` }]}>
-                                <Text style={[styles.statusText, { color: st.color }]}>{st.label}</Text>
-                            </View>
-                        </View>
-                    </View>
-                </View>
-            </TouchableOpacity>
-        );
-    }, [theme, router]);
-
-    const keyExtractor = useCallback((item: DonationRecord) => item.id, []);
-
-    const ListHeader = (
-        <View style={styles.listHeader}>
-            {/* Impact stats */}
-            <View style={[styles.statsCard, { backgroundColor: theme.card, borderColor: theme.border }]}>
-                <StatCell value={String(profile?.total_donations ?? 0)} label="DONATIONS" color={theme.primary} theme={theme} />
-                <View style={[styles.statDiv, { backgroundColor: theme.border }]} />
-                <StatCell value={String(livesHelped)} label="LIVES HELPED" color={theme.success} theme={theme} />
-                <View style={[styles.statDiv, { backgroundColor: theme.border }]} />
-                <StatCell
-                    value={profile?.last_donation_date ? formatDate(profile.last_donation_date) : '—'}
-                    label="LAST DONATED"
-                    color={theme.textPrimary}
-                    theme={theme}
-                    small
-                />
-            </View>
-
-            {/* Next eligibility */}
-            <View style={[styles.eligibilityCard, {
-                backgroundColor: canDonate && ageOk ? `${theme.success}10` : `${theme.warning}10`,
-                borderColor: canDonate && ageOk ? `${theme.success}25` : `${theme.warning}25`,
-            }]}>
-                <Ionicons
-                  name={canDonate && ageOk ? 'checkmark-circle' : 'time-outline'}
-                  size={22}
-                  color={canDonate && ageOk ? theme.success : theme.warning}
-                />
-                <View style={{ flex: 1 }}>
-                    <Text style={[styles.eligTitle, { color: canDonate && ageOk ? theme.success : theme.warning }]}>
-                        {!ageOk
-                            ? 'Age requirement not met (18+)'
-                            : canDonate
-                                ? 'You are eligible to donate now'
-                                : `Next donation in ${daysLeft} days`}
-                    </Text>
-                    <Text style={[styles.eligSub, { color: theme.textMuted }]}>
-                        {!ageOk
-                            ? 'Blood donors must be 18 or older'
-                            : canDonate
-                                ? 'Help someone who needs your blood today'
-                                : `90-day waiting period after donation`}
-                    </Text>
-                </View>
-            </View>
-
-            <Text style={[styles.sectionTitle, { color: theme.textPrimary }]}>
-                Donation History
-            </Text>
-        </View>
-    );
-
-    return (
-        <SafeAreaView style={[styles.root, { backgroundColor: theme.background }]} edges={['top']}>
-            {/* Header */}
-            <View style={[styles.header, { borderBottomColor: theme.border }]}>
-                <View>
-                    <Text style={[styles.title, { color: theme.textPrimary }]}>My Donations</Text>
-                    <Text style={[styles.subtitle, { color: theme.textMuted }]}>
-                        Your full donation record
-                    </Text>
-                </View>
-            </View>
-
-            <FlatList
-                data={records}
-                keyExtractor={keyExtractor}
-                renderItem={renderItem}
-                ListHeaderComponent={ListHeader}
-                contentContainerStyle={[styles.list, { paddingBottom: TAB_BAR_BOTTOM_INSET + Spacing[4] }]}
-                showsVerticalScrollIndicator={false}
-                refreshControl={
-                    <RefreshControl
-                        refreshing={loading}
-                        onRefresh={fetchHistory}
-                        tintColor={theme.textMuted}
-                        colors={[theme.primary]}
-                    />
-                }
-                ListEmptyComponent={
-                    !loading ? (
-                        <EmptyState
-                            icon="🩸"
-                            title="No donations yet"
-                            description="When you accept and complete a blood donation request, it will appear here."
-                            actionLabel="Find Requests"
-                            onAction={() => router.push('/(tabs)/donors')}
-                        />
-                    ) : null
-                }
+        ListEmptyComponent={
+          !loading ? (
+            <EmptyState
+              iconName="heart-outline"
+              title="No donations yet"
+              description="The first one matters most. Browse compatible requests near you and accept one."
+              actionLabel="Find requests near you"
+              onAction={goFindRequests}
             />
-        </SafeAreaView>
-    );
+          ) : null
+        }
+        showsVerticalScrollIndicator={false}
+      />
+    </SafeAreaView>
+  );
 }
 
-function StatCell({ value, label, color, theme, small }: {
-    value: string; label: string; color: string; theme: any; small?: boolean;
-}) {
-    return (
-        <View style={styles.statCell}>
-            <Text style={[styles.statValue, { color, fontSize: small ? FontSize.sm : FontSize.xl }]}>{value}</Text>
-            <Text style={[styles.statLabel, { color: theme.textMuted }]}>{label}</Text>
-        </View>
-    );
-}
+const StatCell = React.memo(function StatCell({
+  value, label, color, theme, small,
+}: { value: string; label: string; color: string; theme: any; small?: boolean }) {
+  return (
+    <View style={styles.statCell}>
+      <Text
+        style={[
+          styles.statValue,
+          { color, fontSize: small ? FontSize.sm : FontSize.xl },
+        ]}
+        numberOfLines={1}
+      >
+        {value}
+      </Text>
+      <Text style={[styles.statLabel, { color: theme.textMuted }]}>{label}</Text>
+    </View>
+  );
+});
 
 const styles = StyleSheet.create({
-    root: { flex: 1 },
-    header: {
-        flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between',
-        paddingHorizontal: Spacing[5], paddingTop: Spacing[4], paddingBottom: Spacing[3],
-        borderBottomWidth: StyleSheet.hairlineWidth,
-    },
-    title: { fontSize: FontSize.xl, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.snug },
-    subtitle: { fontSize: FontSize.sm, marginTop: 2 },
-    listHeader: { gap: Spacing[4], paddingTop: Spacing[4] },
-    list: { paddingHorizontal: Spacing[5], gap: Spacing[3] },
+  root: { flex: 1 },
+  header: {
+    paddingHorizontal: Spacing[5],
+    paddingTop: Spacing[4],
+    paddingBottom: Spacing[3],
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  sectionLabel: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
+    textTransform: 'uppercase',
+    marginBottom: Spacing[1],
+  },
+  title:    { fontSize: FontSize['2xl'], fontWeight: FontWeight.black, letterSpacing: LetterSpacing.tighter },
+  subtitle: { fontSize: FontSize.sm, marginTop: 2, fontWeight: FontWeight.semibold },
 
-    statsCard: {
-        flexDirection: 'row', alignItems: 'center',
-        borderRadius: Radius.md, borderWidth: StyleSheet.hairlineWidth,
-        paddingVertical: Spacing[4],
-    },
-    statCell: { flex: 1, alignItems: 'center', gap: 3 },
-    statValue: { fontWeight: FontWeight.black, letterSpacing: LetterSpacing.tight },
-    statLabel: { fontSize: FontSize['2xs'], fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.widest, textTransform: 'uppercase', textAlign: 'center' },
-    statDiv: { width: StyleSheet.hairlineWidth, height: 32 },
+  statsCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: Radius.xl,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingVertical: Spacing[4],
+  },
+  statCell:  { flex: 1, alignItems: 'center', gap: 3, paddingHorizontal: Spacing[2] },
+  statValue: {
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.tight,
+    textAlign: 'center',
+  },
+  statLabel: {
+    fontSize: FontSize['2xs'],
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
+    textTransform: 'uppercase',
+    textAlign: 'center',
+  },
+  statDiv: { width: StyleSheet.hairlineWidth, height: 36 },
 
-    eligibilityCard: {
-        flexDirection: 'row', alignItems: 'center', gap: Spacing[3],
-        padding: Spacing[4], borderRadius: Radius.md, borderWidth: 1,
-    },
-    eligTitle: { fontSize: FontSize.sm, fontWeight: FontWeight.bold },
-    eligSub: { fontSize: FontSize.xs, marginTop: 2 },
+  eligibilityCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing[3],
+    padding: Spacing[4],
+    borderRadius: Radius.xl,
+    borderWidth: 1.5,
+  },
+  eligIconWrap: {
+    width: 36, height: 36, borderRadius: Radius.pill,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  eligTitle: { fontSize: FontSize.sm, fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.snug },
+  eligSub:   { fontSize: FontSize.xs, marginTop: 2, lineHeight: FontSize.xs * 1.5 },
 
-    sectionTitle: { fontSize: FontSize.md, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.snug },
+  sectionTitle: {
+    fontSize: FontSize.lg,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.tight,
+    marginTop: Spacing[2],
+  },
 
-    row: {
-        flexDirection: 'row', borderRadius: Radius.md,
-        borderWidth: StyleSheet.hairlineWidth, overflow: 'hidden',
-    },
-    stripe: { width: 4, flexShrink: 0 },
-    rowBody: { flex: 1, padding: Spacing[4] },
-    rowTop: { flexDirection: 'row', alignItems: 'flex-start', gap: Spacing[3] },
-    rowMeta: { flex: 1, gap: 3 },
-    hospital: { fontSize: FontSize.sm, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.snug },
-    addr: { fontSize: FontSize.xs },
-    time: { fontSize: FontSize.xs },
-    statusPill: {
-        paddingHorizontal: Spacing[2], paddingVertical: 3,
-        borderRadius: Radius.full, borderWidth: 1, alignSelf: 'flex-start',
-    },
-    statusText: { fontSize: FontSize['2xs'], fontWeight: FontWeight.black, textTransform: 'uppercase', letterSpacing: LetterSpacing.wide },
+  row: {
+    flexDirection: 'row',
+    borderRadius: Radius.xl,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+  },
+  stripe: { width: 4, flexShrink: 0 },
+  rowBody: { flex: 1, padding: Spacing[4] },
+  rowTop:  { flexDirection: 'row', alignItems: 'flex-start', gap: Spacing[3] },
+  rowMeta: { flex: 1, gap: 3 },
+  hospital:{ fontSize: FontSize.sm, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.snug },
+  addr:    { fontSize: FontSize.xs },
+  time:    { fontSize: FontSize.xs },
+  statusPill: {
+    flexDirection: 'row', alignItems: 'center', gap: 4,
+    paddingHorizontal: Spacing[2], paddingVertical: 4,
+    borderRadius: Radius.pill, borderWidth: 1, alignSelf: 'flex-start',
+  },
+  statusText: {
+    fontSize: FontSize['2xs'], fontWeight: FontWeight.black,
+    textTransform: 'uppercase', letterSpacing: LetterSpacing.widest,
+  },
 });

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,33 +1,46 @@
 // app/(tabs)/index.tsx
-import React, { useCallback, useMemo } from 'react';
+// Donor home. Lever: scent of urgency (Critical band pinned) + Fitts's Law
+// on Accept + identity ("Your blood, near you, right now"). 120 fps target —
+// every list cell is memoized, every callback is stable.
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  View, Text, ScrollView, StyleSheet, TouchableOpacity,
-  RefreshControl, useWindowDimensions, Animated,
+  View, Text, StyleSheet, Pressable, RefreshControl,
 } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { useLocation } from '@/hooks/useLocation';
 import { useNearbyRequests } from '@/hooks/useRequests';
 import { useNotifications } from '@/hooks/useNotifications';
+import { supabase } from '@/utils/supabase';
 import StatsBanner from '@/components/StatsBanner';
 import RequestCard from '@/components/RequestCard';
 import BloodGroupBadge from '@/components/BloodGroupBadge';
-import EmptyState from '@/components/EmptyState';
 import {
-  FontSize, FontWeight, Spacing, Radius,
-  LetterSpacing, TAB_BAR_BOTTOM_INSET,
+  FontSize, FontWeight, Spacing, Radius, LetterSpacing,
+  TAB_BAR_BOTTOM_INSET, Elevation,
 } from '@/constants/Typography';
 import { DONOR_FOR_RECIPIENT } from '@/constants/BloodData';
 import { canDonateAgain } from '@/utils/helpers';
+import type { BloodRequest } from '@/hooks/useRequests';
+
+type Section =
+  | { kind: 'critical-header'; key: string; count: number }
+  | { kind: 'feed-header';     key: string; count: number }
+  | { kind: 'feed-empty';      key: string }
+  | { kind: 'request';         key: string; request: BloodRequest }
+  | { kind: 'see-all';         key: string; total: number };
 
 export default function HomeScreen() {
   const { theme } = useTheme();
   const { profile } = useAuth();
-  const router   = useRouter();
-  const insets   = useSafeAreaInsets();
-  const { width } = useWindowDimensions();
+  const router  = useRouter();
+  const insets  = useSafeAreaInsets();
 
   const { location, loading: locLoading, refreshLocation } = useLocation(true);
   const { requests, loading: reqLoading, refetch } = useNearbyRequests(
@@ -38,268 +51,535 @@ export default function HomeScreen() {
 
   const { canDonate, daysLeft } = canDonateAgain(profile?.last_donation_date ?? null);
 
-  // Filter to blood-compatible requests
+  // Active-commitment banner: if this donor has already accepted an active
+  // request, surface a prominent pill on the home so they can return to it
+  // quickly. Mirrors the server-side one-active-commitment rule enforced in
+  // accept_blood_request.
+  const [activeCommitment, setActiveCommitment] = useState<{
+    requestId: string; hospital: string | null; bloodGroup: string | null;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!profile?.id) { setActiveCommitment(null); return; }
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const { data, error } = await supabase
+          .from('request_responses')
+          .select('request_id, blood_requests!inner(id, status, hospital_name, blood_group)')
+          .eq('donor_id', profile.id)
+          .eq('status', 'accepted')
+          .eq('blood_requests.status', 'active')
+          .limit(1)
+          .maybeSingle();
+        if (cancelled) return;
+        if (error) { console.warn('[activeCommitment]', error.message); setActiveCommitment(null); return; }
+        if (!data) { setActiveCommitment(null); return; }
+        const br: any = (data as any).blood_requests;
+        setActiveCommitment({
+          requestId: (data as any).request_id,
+          hospital:  br?.hospital_name ?? null,
+          bloodGroup: br?.blood_group ?? null,
+        });
+      } catch (e: any) {
+        if (!cancelled) console.warn('[activeCommitment]', e?.message);
+      }
+    };
+    load();
+
+    const ch = supabase
+      .channel(`home_my_resps_${profile.id}_${Date.now()}`)
+      .on('postgres_changes', {
+        event: '*', schema: 'public',
+        table: 'request_responses',
+        filter: `donor_id=eq.${profile.id}`,
+      }, () => load())
+      .subscribe();
+
+    return () => { cancelled = true; supabase.removeChannel(ch); };
+  }, [profile?.id]);
+
   const compatible = useMemo(() => {
     if (!profile?.blood_group) return requests;
-    const map = DONOR_FOR_RECIPIENT;
     return requests.filter(r =>
-      (map[r.blood_group as keyof typeof map] ?? [])
-        .includes(profile.blood_group as any)
+      (DONOR_FOR_RECIPIENT[r.blood_group as keyof typeof DONOR_FOR_RECIPIENT] ?? [])
+        .includes(profile.blood_group as any),
     );
   }, [requests, profile?.blood_group]);
 
-  const criticalCount = compatible.filter(r => r.urgency === 'critical').length;
+  const critical = useMemo(
+    () => compatible.filter(r => r.urgency === 'critical'),
+    [compatible],
+  );
+  const others = useMemo(
+    () => compatible.filter(r => r.urgency !== 'critical').slice(0, 12),
+    [compatible],
+  );
+
+  // Build a flat section list optimised for FlashList recycling.
+  // When there are zero compatibles, we inject a `feed-empty` row right after
+  // the feed-header so the user always sees a clear "nothing here yet" state
+  // anchored under the section label (instead of just empty space).
+  const data = useMemo<Section[]>(() => {
+    const out: Section[] = [];
+    if (critical.length > 0) {
+      out.push({ kind: 'critical-header', key: 'crit-h', count: critical.length });
+      critical.forEach(r => out.push({ kind: 'request', key: `c-${r.id}`, request: r }));
+    }
+    out.push({ kind: 'feed-header', key: 'feed-h', count: compatible.length });
+    if (compatible.length === 0) {
+      out.push({ kind: 'feed-empty', key: 'feed-empty' });
+    } else {
+      others.forEach(r => out.push({ kind: 'request', key: `r-${r.id}`, request: r }));
+      if (compatible.length > others.length + critical.length) {
+        out.push({ kind: 'see-all', key: 'see-all', total: compatible.length });
+      }
+    }
+    return out;
+  }, [critical, others, compatible]);
 
   const onRefresh = useCallback(async () => {
     await Promise.all([refreshLocation(), refetch()]);
   }, [refreshLocation, refetch]);
 
-  const hour      = new Date().getHours();
-  const greeting  = hour < 5 ? 'Still up?' : hour < 12 ? 'Good morning' : hour < 17 ? 'Good afternoon' : 'Good evening';
+  const greeting = useMemo(() => {
+    const h = new Date().getHours();
+    return h < 5 ? 'Still up?' : h < 12 ? 'Good morning' : h < 17 ? 'Good afternoon' : 'Good evening';
+  }, []);
   const firstName = profile?.full_name?.split(' ')[0] ?? '';
+  const available = !!(profile?.is_available_to_donate && canDonate);
 
-  const available      = profile?.is_available_to_donate && canDonate;
-  const statusColor    = available ? '#00A651' : theme.warning;
+  const onRequestPress = useCallback((r: BloodRequest) => {
+    Haptics.selectionAsync().catch(() => {});
+    router.push(`/request/${r.id}` as any);
+  }, [router]);
 
-  // Psychology: show different CTAs based on state
-  const heroMessage = criticalCount > 0
-    ? `${criticalCount} critical request${criticalCount === 1 ? '' : 's'} near you`
-    : compatible.length > 0
-    ? `${compatible.length} ${profile?.blood_group ?? ''} compatible request${compatible.length === 1 ? '' : 's'} nearby`
-    : `You're all caught up`;
+  const onSeeAll = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    router.push('/(tabs)/donors' as any);
+  }, [router]);
 
-  return (
-    <ScrollView
-      style={[styles.root, { backgroundColor: theme.background }]}
-      contentContainerStyle={[
-        styles.content,
-        { paddingTop: insets.top + Spacing[5], paddingBottom: TAB_BAR_BOTTOM_INSET + Spacing[4] },
-      ]}
-      showsVerticalScrollIndicator={false}
-      refreshControl={
-        <RefreshControl
-          refreshing={locLoading || reqLoading}
-          onRefresh={onRefresh}
-          tintColor={theme.textMuted}
-          colors={[theme.primary]}
-        />
-      }
-    >
-      {/* ── Header ── */}
-      <View style={styles.header}>
+  const goRequestTab = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    router.push('/(tabs)/request' as any);
+  }, [router]);
+
+  const goProfileTab = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    router.push('/(tabs)/profile' as any);
+  }, [router]);
+
+  const openCommitment = useCallback(() => {
+    if (!activeCommitment) return;
+    Haptics.selectionAsync().catch(() => {});
+    router.push(`/request/${activeCommitment.requestId}` as any);
+  }, [router, activeCommitment]);
+
+  const renderItem = useCallback(({ item }: { item: Section }) => {
+    if (item.kind === 'critical-header') {
+      return (
+        <View style={styles.sectionWrap}>
+          <Text style={[styles.sectionLabel, { color: theme.textMuted }]}>
+            Critical · {item.count} need{item.count !== 1 ? '' : 's'} you now
+          </Text>
+          <View style={[styles.criticalBadge, { backgroundColor: theme.primarySoft, borderColor: theme.primary }]}>
+            <Ionicons name="flash" size={14} color={theme.primary} />
+            <Text style={[styles.criticalText, { color: theme.primary }]}>
+              Tap a card to head over
+            </Text>
+          </View>
+        </View>
+      );
+    }
+    if (item.kind === 'feed-header') {
+      return (
+        <View style={[styles.sectionWrap, styles.feedHeader]}>
+          <Text style={[styles.sectionLabel, { color: theme.textMuted, flex: 1 }]}>
+            Nearby requests
+          </Text>
+          {item.count > 0 && (
+            <View style={[styles.countPill, { backgroundColor: theme.primarySoft }]}>
+              <Text style={[styles.countText, { color: theme.primary }]}>{item.count}</Text>
+            </View>
+          )}
+        </View>
+      );
+    }
+    if (item.kind === 'request') {
+      return (
+        <View style={styles.cardWrap}>
+          <RequestCard
+            request={item.request}
+            userLat={location?.latitude ?? null}
+            userLon={location?.longitude ?? null}
+            onPress={onRequestPress}
+            showActions
+            onAccept={onRequestPress}
+          />
+        </View>
+      );
+    }
+    if (item.kind === 'feed-empty') {
+      return (
+        <View style={[styles.emptyCard, { backgroundColor: theme.cardElevated, borderColor: theme.border }]}>
+          <View style={[styles.emptyIconWrap, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+            <Ionicons name="search" size={20} color={theme.textMuted} />
+          </View>
+          <Text style={[styles.emptyTitle, { color: theme.textPrimary }]}>All quiet near you</Text>
+          <Text style={[styles.emptyBody, { color: theme.textMuted }]}>
+            No compatible requests in your area right now. We'll ping you the moment one lands — stay ready.
+          </Text>
+        </View>
+      );
+    }
+    return (
+      <Pressable
+        onPress={onSeeAll}
+        style={({ pressed }) => [
+          styles.seeAllBtn,
+          {
+            backgroundColor: theme.cardElevated,
+            borderColor: theme.border,
+            opacity: pressed ? 0.9 : 1,
+          },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel="See all requests"
+      >
+        <Text style={[styles.seeAllText, { color: theme.textPrimary }]}>
+          See all {item.total} requests
+        </Text>
+        <Ionicons name="chevron-forward" size={16} color={theme.textPrimary} />
+      </Pressable>
+    );
+  }, [theme, location?.latitude, location?.longitude, onRequestPress, onSeeAll]);
+
+  const keyExtractor = useCallback((it: Section) => it.key, []);
+
+  const Header = useMemo(() => (
+    <View style={[styles.headerWrap, { paddingTop: insets.top + Spacing[5] }]}>
+      <View style={styles.greetingRow}>
         <View style={{ flex: 1 }}>
           <Text style={[styles.greeting, { color: theme.textMuted }]}>
             {greeting}{firstName ? `, ${firstName}` : ''}
           </Text>
-          {/* Hero message — urgency / social proof */}
-          <Text style={[
-            styles.heroMsg,
-            {
-              color: criticalCount > 0 ? theme.primary : theme.textPrimary,
-              fontSize: criticalCount > 0 ? FontSize['2xl'] : FontSize.xl,
-            },
-          ]} numberOfLines={2}>
-            {heroMessage}
+          <Text style={[styles.hero, { color: theme.textPrimary }]} numberOfLines={2}>
+            {activeCommitment
+              ? "You're on the way — finish this donation"
+              : critical.length > 0
+                ? `${critical.length} critical request${critical.length === 1 ? '' : 's'} near you`
+                : compatible.length > 0
+                  ? `${compatible.length} compatible request${compatible.length === 1 ? '' : 's'} nearby`
+                  : "All quiet. Stay ready."}
           </Text>
         </View>
         {profile?.blood_group && (
-          <BloodGroupBadge bloodGroup={profile.blood_group} size="xl" inverted />
+          <BloodGroupBadge bloodGroup={profile.blood_group} size="lg" variant="solid" />
         )}
       </View>
 
-      {/* ── Availability strip ── */}
-      {profile && (
-        <TouchableOpacity
-          onPress={() => router.push('/(tabs)/profile')}
-          style={[styles.availStrip, { backgroundColor: theme.card, borderColor: theme.border }]}
-          activeOpacity={0.8}
+      {/* ── Active-commitment banner (Uber "ride in progress" pattern) ──── */}
+      {activeCommitment && (
+        <Pressable
+          onPress={openCommitment}
+          style={({ pressed }) => [
+            styles.commitmentBanner,
+            { backgroundColor: theme.primary, opacity: pressed ? 0.94 : 1 },
+            Elevation.lg,
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Open your active donation commitment"
         >
-          <View style={[styles.availDot, { backgroundColor: statusColor }]} />
-          <Text style={[styles.availText, { color: theme.textPrimary }]} numberOfLines={1}>
-            {available
-              ? 'You are available to donate'
-              : daysLeft > 0
-              ? `Next eligible donation in ${daysLeft} days`
-              : 'Donations paused — tap to update'}
-          </Text>
-          <Text style={[styles.availCount, { color: theme.textMuted }]}>
-            {profile.total_donations} donations ›
-          </Text>
-        </TouchableOpacity>
+          <View style={styles.commitmentDotWrap}>
+            <View style={[styles.commitmentDotOuter, { backgroundColor: theme.textOnPrimary + '40' }]} />
+            <View style={[styles.commitmentDot,      { backgroundColor: theme.textOnPrimary }]} />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text style={[styles.commitmentLabel, { color: theme.textOnPrimary, opacity: 0.85 }]}>
+              ACTIVE COMMITMENT
+            </Text>
+            <Text style={[styles.commitmentTitle, { color: theme.textOnPrimary }]} numberOfLines={1}>
+              {activeCommitment.bloodGroup ? `${activeCommitment.bloodGroup} · ` : ''}
+              {activeCommitment.hospital ?? 'Donation in progress'}
+            </Text>
+          </View>
+          <Ionicons name="chevron-forward" size={20} color={theme.textOnPrimary} />
+        </Pressable>
       )}
 
-      {/* ── Quick action cards ── */}
-      <View style={styles.qaRow}>
-        {/* PRIMARY — need blood (high contrast, full red) */}
-        <TouchableOpacity
-          onPress={() => router.push('/(tabs)/request')}
-          style={[styles.qaCard, styles.qaCardPrimary, { backgroundColor: theme.primary }]}
-          activeOpacity={0.82}
-        >
-          <Text style={styles.qaEmoji}>🆘</Text>
-          <Text style={styles.qaTitleWhite}>Need Blood</Text>
-          <Text style={styles.qaSubWhite}>Post emergency request</Text>
-          <View style={styles.qaArrow}>
-            <Text style={styles.qaArrowText}>→</Text>
-          </View>
-        </TouchableOpacity>
+      <Pressable
+        onPress={goProfileTab}
+        style={({ pressed }) => [
+          styles.availPill,
+          {
+            backgroundColor: theme.cardElevated,
+            borderColor: theme.border,
+            opacity: pressed ? 0.92 : 1,
+          },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel="Open profile"
+      >
+        <View style={[styles.availDot, { backgroundColor: available ? theme.success : theme.warning }]} />
+        <Text style={[styles.availText, { color: theme.textPrimary }]} numberOfLines={1}>
+          {available
+            ? "You're available to donate"
+            : daysLeft > 0
+              ? `Eligible again in ${daysLeft} day${daysLeft === 1 ? '' : 's'}`
+              : 'Paused — tap to update'}
+        </Text>
+        <Text style={[styles.availCount, { color: theme.textMuted }]}>
+          {profile?.total_donations ?? 0} donations
+        </Text>
+        <Ionicons name="chevron-forward" size={14} color={theme.textMuted} />
+      </Pressable>
 
-        {/* SECONDARY — find & donate */}
-        <TouchableOpacity
-          onPress={() => router.push('/(tabs)/donors')}
-          style={[styles.qaCard, { backgroundColor: theme.card, borderColor: theme.border, borderWidth: StyleSheet.hairlineWidth }]}
-          activeOpacity={0.82}
+      <View style={styles.quickRow}>
+        <Pressable
+          onPress={goRequestTab}
+          style={({ pressed }) => [
+            styles.quickCard,
+            { backgroundColor: theme.primary, opacity: pressed ? 0.92 : 1 },
+            Elevation.sm,
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Need blood — post a request"
         >
-          <Text style={styles.qaEmoji}>🗺️</Text>
-          <Text style={[styles.qaTitle, { color: theme.textPrimary }]}>Find & Donate</Text>
-          <Text style={[styles.qaSub, { color: theme.textSecondary }]}>Browse requests nearby</Text>
-          <View style={styles.qaArrow}>
-            <Text style={[styles.qaArrowText, { color: theme.textMuted }]}>→</Text>
-          </View>
-        </TouchableOpacity>
+          <Ionicons name="add-circle" size={22} color={theme.textOnPrimary} />
+          <Text style={[styles.quickTitle, { color: theme.textOnPrimary }]}>Need blood</Text>
+          <Text style={[styles.quickSub, { color: theme.textOnPrimary, opacity: 0.85 }]}>
+            Post a request
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={onSeeAll}
+          style={({ pressed }) => [
+            styles.quickCard,
+            { backgroundColor: theme.cardElevated, borderColor: theme.border, borderWidth: StyleSheet.hairlineWidth, opacity: pressed ? 0.92 : 1 },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Find requests near me"
+        >
+          <Ionicons name="search" size={22} color={theme.textPrimary} />
+          <Text style={[styles.quickTitle, { color: theme.textPrimary }]}>Find</Text>
+          <Text style={[styles.quickSub, { color: theme.textMuted }]}>
+            Browse nearby
+          </Text>
+        </Pressable>
       </View>
 
-      {/* ── Community stats (social proof) ── */}
       <StatsBanner />
+    </View>
+  ), [
+    insets.top, theme, greeting, firstName, critical.length, compatible.length,
+    profile?.blood_group, profile?.total_donations, available, daysLeft,
+    goRequestTab, onSeeAll, goProfileTab,
+    activeCommitment, openCommitment,
+  ]);
 
-      {/* ── Critical requests pinned at top (urgency + scarcity) ── */}
-      {criticalCount > 0 && (
-        <View style={styles.section}>
-          <View style={styles.sectionHeader}>
-            <View style={[styles.criticalBadge, { backgroundColor: theme.primarySoft, borderColor: theme.primary }]}>
-              <Text style={[styles.criticalBadgeText, { color: theme.primary }]}>
-                CRITICAL · NEEDS IMMEDIATE RESPONSE
-              </Text>
-            </View>
-          </View>
-          {compatible
-            .filter(r => r.urgency === 'critical')
-            .map(req => (
-              <RequestCard
-                key={req.id}
-                request={req}
-                userLat={location?.latitude}
-                userLon={location?.longitude}
-                onPress={r => router.push(`/request/${r.id}`)}
-                showActions
-                onAccept={r => router.push(`/request/${r.id}`)}
-              />
-            ))}
-        </View>
-      )}
+  // No ListEmptyComponent: `data` always contains the feed-header (and a
+  // feed-empty row when compatible is zero), so the FlashList is never
+  // technically empty. The feed-empty Section kind renders the zero-state
+  // card right under the section label.
 
-      {/* ── All compatible requests ── */}
-      <View style={styles.section}>
-        <View style={styles.sectionHeader}>
-          <Text style={[styles.sectionTitle, { color: theme.textPrimary }]}>
-            Nearby Requests
-          </Text>
-          {compatible.length > 0 && (
-            <View style={[styles.countBadge, { backgroundColor: theme.primaryMuted }]}>
-              <Text style={[styles.countText, { color: theme.primary }]}>
-                {compatible.length}
-              </Text>
-            </View>
-          )}
-        </View>
-
-        {compatible.length === 0 ? (
-          <EmptyState
-            icon="📍"
-            title="No compatible requests nearby"
-            description="When someone nearby needs blood compatible with yours, you'll see it here in real time."
-          />
-        ) : (
-          <>
-            {compatible
-              .filter(r => r.urgency !== 'critical') // critical already shown above
-              .slice(0, 6)
-              .map(req => (
-                <RequestCard
-                  key={req.id}
-                  request={req}
-                  userLat={location?.latitude}
-                  userLon={location?.longitude}
-                  onPress={r => router.push(`/request/${r.id}`)}
-                  showActions
-                  onAccept={r => router.push(`/request/${r.id}`)}
-                />
-              ))}
-
-            {compatible.length > 6 && (
-              <TouchableOpacity
-                onPress={() => router.push('/(tabs)/donors')}
-                style={[styles.seeAllBtn, { borderColor: theme.border }]}
-                activeOpacity={0.7}
-              >
-                <Text style={[styles.seeAllText, { color: theme.textPrimary }]}>
-                  See all {compatible.length} requests  →
-                </Text>
-              </TouchableOpacity>
-            )}
-          </>
-        )}
-      </View>
-    </ScrollView>
+  return (
+    <FlashList
+      data={data}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      ListHeaderComponent={Header}
+      contentContainerStyle={{
+        paddingHorizontal: Spacing[5],
+        paddingBottom: TAB_BAR_BOTTOM_INSET + Spacing[4],
+      }}
+      getItemType={(it) =>
+        it.kind === 'request'    ? 'card'
+        : it.kind === 'see-all'  ? 'see-all'
+        : it.kind === 'feed-empty' ? 'empty'
+        : 'header'
+      }
+      refreshControl={
+        // Truly silent pull-to-refresh.
+        //
+        // `refreshing` stays HARD-CODED to false — flipping it true while
+        // data fetches makes Android allocate layout space for the
+        // (invisible) indicator, causing the visible jitter the user
+        // complained about. With refreshing perma-false:
+        //   • The pull gesture still fires onRefresh → data is refetched.
+        //   • No native spinner ever renders.
+        //   • No layout space is ever reserved.
+        //   • The FlashList re-renders in place when the new data lands.
+        // Loading state is reflected by the data updating — no visible
+        // refresh affordance at all, per project rule "no spinners".
+        <RefreshControl
+          refreshing={false}
+          onRefresh={onRefresh}
+          tintColor="transparent"
+          colors={['transparent']}
+          progressBackgroundColor="transparent"
+          progressViewOffset={-1000}
+        />
+      }
+      showsVerticalScrollIndicator={false}
+      style={{ backgroundColor: theme.background }}
+    />
   );
 }
 
 const styles = StyleSheet.create({
-  root:    { flex: 1 },
-  content: { paddingHorizontal: Spacing[5], gap: Spacing[5] },
-
-  header: {
+  headerWrap: { gap: Spacing[5], marginBottom: Spacing[5] },
+  greetingRow: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
     alignItems: 'flex-end',
-    gap: Spacing[4],
+    gap: Spacing[3],
   },
-  greeting: { fontSize: FontSize.sm, fontWeight: FontWeight.medium, marginBottom: Spacing[1] },
-  heroMsg:  {
+  greeting: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.semibold,
+    marginBottom: Spacing[1],
+  },
+  hero: {
+    fontSize: FontSize['2xl'],
     fontWeight: FontWeight.black,
-    letterSpacing: LetterSpacing.tight,
+    letterSpacing: LetterSpacing.tighter,
     lineHeight: FontSize['2xl'] * 1.1,
   },
 
-  availStrip: {
-    flexDirection: 'row', alignItems: 'center', gap: Spacing[3],
-    padding: Spacing[4], borderRadius: Radius.sm, borderWidth: StyleSheet.hairlineWidth,
+  commitmentBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing[3],
+    paddingVertical: Spacing[3],
+    paddingHorizontal: Spacing[4],
+    borderRadius: Radius.xl,
+  },
+  commitmentDotWrap: {
+    width: 14, height: 14,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  commitmentDotOuter: {
+    position: 'absolute',
+    width: 14, height: 14, borderRadius: 7,
+  },
+  commitmentDot: { width: 8, height: 8, borderRadius: 4 },
+  commitmentLabel: {
+    fontSize: FontSize['2xs'],
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
+    textTransform: 'uppercase',
+  },
+  commitmentTitle: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.snug,
+    marginTop: 2,
+  },
+
+  availPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing[2],
+    paddingVertical: Spacing[3],
+    paddingHorizontal: Spacing[4],
+    borderRadius: Radius.pill,
+    borderWidth: StyleSheet.hairlineWidth,
   },
   availDot:   { width: 8, height: 8, borderRadius: 4, flexShrink: 0 },
-  availText:  { flex: 1, fontSize: FontSize.sm, fontWeight: FontWeight.medium },
-  availCount: { fontSize: FontSize.xs, flexShrink: 0 },
+  availText:  { flex: 1, fontSize: FontSize.sm, fontWeight: FontWeight.semibold, letterSpacing: LetterSpacing.snug },
+  availCount: { fontSize: FontSize.xs, fontWeight: FontWeight.semibold },
 
-  qaRow: { flexDirection: 'row', gap: Spacing[3] },
-  qaCard: {
-    flex: 1, borderRadius: Radius.md, padding: Spacing[4],
-    gap: Spacing[1], position: 'relative',
+  quickRow: { flexDirection: 'row', gap: Spacing[3] },
+  quickCard: {
+    flex: 1,
+    padding: Spacing[4],
+    borderRadius: Radius.xl,
+    gap: Spacing[1],
   },
-  qaCardPrimary: {},
-  qaEmoji:       { fontSize: 26, marginBottom: Spacing[1] },
-  qaTitleWhite:  { fontSize: FontSize.base, fontWeight: FontWeight.black, color: '#fff', letterSpacing: LetterSpacing.snug },
-  qaTitle:       { fontSize: FontSize.base, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.snug },
-  qaSubWhite:    { fontSize: FontSize.xs, color: 'rgba(255,255,255,0.72)', lineHeight: 18 },
-  qaSub:         { fontSize: FontSize.xs, lineHeight: 18 },
-  qaArrow: {
-    position: 'absolute', top: Spacing[4], right: Spacing[4],
+  quickTitle: {
+    fontSize: FontSize.base,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.snug,
+    marginTop: Spacing[2],
   },
-  qaArrowText: { fontSize: FontSize.base, fontWeight: FontWeight.bold, color: 'rgba(255,255,255,0.7)' },
+  quickSub: { fontSize: FontSize.xs, fontWeight: FontWeight.semibold, marginTop: 2 },
 
-  section:       { gap: Spacing[3] },
-  sectionHeader: { flexDirection: 'row', alignItems: 'center', gap: Spacing[3] },
-  sectionTitle:  { fontSize: FontSize.md, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.snug, flex: 1 },
-  countBadge:    { paddingHorizontal: Spacing[3], paddingVertical: 3, borderRadius: Radius.full },
-  countText:     { fontSize: FontSize.xs, fontWeight: FontWeight.black },
+  sectionWrap:  { marginTop: Spacing[5], marginBottom: Spacing[2], gap: Spacing[2] },
+  feedHeader:   { flexDirection: 'row', alignItems: 'center', gap: Spacing[2] },
+  sectionLabel: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
+    textTransform: 'uppercase',
+    marginLeft: Spacing[2],
+  },
+  countPill: {
+    paddingHorizontal: Spacing[3],
+    paddingVertical: 4,
+    borderRadius: Radius.pill,
+  },
+  countText: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.snug,
+  },
 
   criticalBadge: {
-    flex: 1, padding: Spacing[3], borderRadius: Radius.xs, borderWidth: 1,
+    flexDirection: 'row',
     alignItems: 'center',
+    gap: Spacing[2],
+    paddingVertical: Spacing[3],
+    paddingHorizontal: Spacing[4],
+    borderRadius: Radius.pill,
+    borderWidth: 1.5,
   },
-  criticalBadgeText: { fontSize: FontSize.xs, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.wide, textTransform: 'uppercase' },
+  criticalText: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.bold,
+    letterSpacing: LetterSpacing.snug,
+    flex: 1,
+  },
+
+  cardWrap: { marginTop: 0 },
+
+  emptyCard: {
+    alignItems: 'center',
+    padding: Spacing[5],
+    gap: Spacing[2],
+    borderRadius: Radius.xl,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginTop: Spacing[2],
+  },
+  emptyIconWrap: {
+    width: 44, height: 44, borderRadius: Radius.pill,
+    alignItems: 'center', justifyContent: 'center',
+    borderWidth: StyleSheet.hairlineWidth,
+    marginBottom: Spacing[1],
+  },
+  emptyTitle: {
+    fontSize: FontSize.base,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.snug,
+  },
+  emptyBody: {
+    fontSize: FontSize.sm,
+    textAlign: 'center',
+    lineHeight: FontSize.sm * 1.5,
+    paddingHorizontal: Spacing[2],
+  },
 
   seeAllBtn: {
-    padding: Spacing[4], borderRadius: Radius.sm,
-    borderWidth: StyleSheet.hairlineWidth, alignItems: 'center',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing[2],
+    paddingVertical: Spacing[4],
+    borderRadius: Radius.pill,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginTop: Spacing[2],
   },
-  seeAllText: { fontSize: FontSize.sm, fontWeight: FontWeight.bold },
+  seeAllText: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.bold,
+    letterSpacing: LetterSpacing.snug,
+  },
 });

--- a/mobile/app/(tabs)/my-requests.tsx
+++ b/mobile/app/(tabs)/my-requests.tsx
@@ -1,24 +1,32 @@
 // app/(tabs)/my-requests.tsx
-import React, { useCallback, useState } from 'react';
-import {
-  View, Text, StyleSheet, FlatList, TouchableOpacity,
-} from 'react-native';
+// Lever: control + closure. The recipient sees every request they've posted,
+// filtered by status. Each card taps through to the full detail modal where
+// they manage accepted donors / completions / cancellation.
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { View, Text, StyleSheet, Pressable, RefreshControl } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/contexts/ThemeContext';
-import { useMyRequests, BloodRequest } from '@/hooks/useRequests';
+import { useMyRequests, type BloodRequest } from '@/hooks/useRequests';
 import RequestCard from '@/components/RequestCard';
 import EmptyState from '@/components/EmptyState';
-import { FontSize, FontWeight, Spacing, Radius, LetterSpacing } from '@/constants/Typography';
+import {
+  FontSize, FontWeight, Spacing, Radius, LetterSpacing,
+  TAB_BAR_BOTTOM_INSET, Elevation,
+} from '@/constants/Typography';
 
 type Filter = 'all' | 'active' | 'fulfilled' | 'cancelled';
 
-const FILTERS: { label: string; value: Filter }[] = [
+const FILTERS: ReadonlyArray<{ label: string; value: Filter }> = [
   { label: 'All',       value: 'all' },
   { label: 'Active',    value: 'active' },
   { label: 'Fulfilled', value: 'fulfilled' },
   { label: 'Cancelled', value: 'cancelled' },
-];
+] as const;
 
 export default function MyRequestsScreen() {
   const { theme } = useTheme();
@@ -27,38 +35,66 @@ export default function MyRequestsScreen() {
   const { requests, loading, refetch } = useMyRequests();
   const [filter, setFilter] = useState<Filter>('all');
 
-  const filtered = filter === 'all'
-    ? requests
-    : requests.filter(r => r.status === filter);
+  const filtered = useMemo(
+    () => filter === 'all' ? requests : requests.filter(r => r.status === filter),
+    [requests, filter],
+  );
+
+  const onCardPress = useCallback((r: BloodRequest) => {
+    Haptics.selectionAsync().catch(() => {});
+    router.push(`/request/${r.id}` as any);
+  }, [router]);
+
+  const onFilter = useCallback((value: Filter) => {
+    Haptics.selectionAsync().catch(() => {});
+    setFilter(value);
+  }, []);
 
   const renderItem = useCallback(({ item }: { item: BloodRequest }) => (
-    <RequestCard
-      request={item}
-      onPress={r => router.push(`/request/${r.id}`)}
-    />
-  ), [router]);
+    <RequestCard request={item} onPress={onCardPress} />
+  ), [onCardPress]);
 
   const keyExtractor = useCallback((item: BloodRequest) => item.id, []);
 
+  const newRequest = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    router.push('/(tabs)/request' as any);
+  }, [router]);
+
   return (
     <View style={[styles.root, { backgroundColor: theme.background }]}>
-
       {/* Header */}
-      <View style={[styles.header, { paddingTop: insets.top + Spacing[5], borderBottomColor: theme.border, backgroundColor: theme.surface }]}>
+      <View
+        style={[
+          styles.header,
+          {
+            paddingTop: insets.top + Spacing[4],
+            backgroundColor: theme.surface,
+            borderBottomColor: theme.border,
+          },
+        ]}
+      >
         <View style={styles.headerRow}>
-          <View>
-            <Text style={[styles.title, { color: theme.textPrimary }]}>My Requests</Text>
+          <View style={{ flex: 1 }}>
+            <Text style={[styles.sectionLabel, { color: theme.textMuted }]}>Control · Your posts</Text>
+            <Text style={[styles.title, { color: theme.textPrimary }]}>Your requests</Text>
             <Text style={[styles.subtitle, { color: theme.textMuted }]}>
-              {requests.length} total
+              {requests.length} {requests.length === 1 ? 'request' : 'requests'} total
             </Text>
           </View>
-          <TouchableOpacity
-            onPress={() => router.push('/(tabs)/request')}
-            style={[styles.newBtn, { backgroundColor: theme.primary }]}
-            activeOpacity={0.8}
+          <Pressable
+            onPress={newRequest}
+            style={({ pressed }) => [
+              styles.newBtn,
+              { backgroundColor: theme.primary, opacity: pressed ? 0.92 : 1 },
+              Elevation.sm,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Post a new request"
           >
-            <Text style={styles.newBtnLabel}>+ New</Text>
-          </TouchableOpacity>
+            <Ionicons name="add" size={16} color={theme.textOnPrimary} />
+            <Text style={[styles.newBtnLabel, { color: theme.textOnPrimary }]}>New</Text>
+          </Pressable>
         </View>
 
         {/* Filter pills */}
@@ -66,41 +102,67 @@ export default function MyRequestsScreen() {
           {FILTERS.map(f => {
             const active = filter === f.value;
             return (
-              <TouchableOpacity
+              <Pressable
                 key={f.value}
-                onPress={() => setFilter(f.value)}
-                style={[styles.pill, {
-                  backgroundColor: active ? theme.textPrimary : theme.card,
-                  borderColor:     active ? theme.textPrimary : theme.border,
-                }]}
-                activeOpacity={0.7}
+                onPress={() => onFilter(f.value)}
+                style={({ pressed }) => [
+                  styles.pill,
+                  {
+                    backgroundColor: active ? theme.textPrimary : theme.cardElevated,
+                    borderColor:     active ? theme.textPrimary : theme.border,
+                    opacity: pressed ? 0.9 : 1,
+                  },
+                ]}
+                accessibilityRole="tab"
+                accessibilityState={{ selected: active }}
+                accessibilityLabel={f.label}
               >
-                <Text style={[styles.pillLabel, { color: active ? theme.textInverse : theme.textSecondary }]}>
+                <Text
+                  style={[
+                    styles.pillLabel,
+                    { color: active ? theme.textInverse : theme.textPrimary },
+                  ]}
+                >
                   {f.label}
                 </Text>
-              </TouchableOpacity>
+              </Pressable>
             );
           })}
         </View>
       </View>
 
-      <FlatList
+      <FlashList
         data={filtered}
         keyExtractor={keyExtractor}
         renderItem={renderItem}
-        contentContainerStyle={[styles.list, { paddingBottom: insets.bottom + Spacing[12] }]}
+        getItemType={() => 'request'}
+        contentContainerStyle={{
+          paddingHorizontal: Spacing[5],
+          paddingTop: Spacing[5],
+          paddingBottom: TAB_BAR_BOTTOM_INSET + Spacing[4],
+        }}
         showsVerticalScrollIndicator={false}
-        onRefresh={refetch}
-        refreshing={loading}
+        refreshControl={
+          <RefreshControl
+            refreshing={false}
+            onRefresh={refetch}
+            tintColor="transparent"
+            colors={['transparent']}
+            progressBackgroundColor="transparent"
+            progressViewOffset={-1000}
+          />
+        }
         ListEmptyComponent={
           <EmptyState
-            icon="📋"
+            iconName={filter === 'all' ? 'document-text-outline' : 'filter-outline'}
             title={filter === 'all' ? 'No requests yet' : `No ${filter} requests`}
-            description={filter === 'all'
-              ? 'Post a blood request and we\'ll match you with compatible donors nearby.'
-              : 'Try a different filter.'}
-            actionLabel={filter === 'all' ? 'Post First Request' : undefined}
-            onAction={filter === 'all' ? () => router.push('/(tabs)/request') : undefined}
+            description={
+              filter === 'all'
+                ? 'Post a request and matched donors near the hospital will be notified within seconds.'
+                : 'Switch the filter above to see other requests.'
+            }
+            actionLabel={filter === 'all' ? 'Post your first request' : undefined}
+            onAction={filter === 'all' ? newRequest : undefined}
           />
         }
       />
@@ -109,15 +171,44 @@ export default function MyRequestsScreen() {
 }
 
 const styles = StyleSheet.create({
-  root:       { flex: 1 },
-  header:     { paddingHorizontal: Spacing[5], paddingBottom: Spacing[3], borderBottomWidth: StyleSheet.hairlineWidth },
-  headerRow:  { flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: Spacing[4] },
-  title:      { fontSize: FontSize.xl, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.tight },
-  subtitle:   { fontSize: FontSize.xs, marginTop: 2 },
-  newBtn:     { paddingHorizontal: Spacing[4], paddingVertical: Spacing[2], borderRadius: Radius.xs },
-  newBtnLabel:{ color: '#fff', fontSize: FontSize.sm, fontWeight: FontWeight.black },
-  filterRow:  { flexDirection: 'row', gap: Spacing[2] },
-  pill:       { paddingHorizontal: Spacing[3], paddingVertical: Spacing[1], borderRadius: Radius.full, borderWidth: StyleSheet.hairlineWidth },
-  pillLabel:  { fontSize: FontSize.xs, fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.wide },
-  list:       { padding: Spacing[5] },
+  root: { flex: 1 },
+  header: {
+    paddingHorizontal: Spacing[5],
+    paddingBottom: Spacing[4],
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: Spacing[4],
+  },
+  headerRow: { flexDirection: 'row', alignItems: 'center', gap: Spacing[3] },
+  sectionLabel: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
+    textTransform: 'uppercase',
+    marginBottom: Spacing[1],
+  },
+  title: {
+    fontSize: FontSize['2xl'], fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.tighter,
+  },
+  subtitle: { fontSize: FontSize.xs, marginTop: 2, fontWeight: FontWeight.semibold, letterSpacing: LetterSpacing.snug },
+  newBtn: {
+    flexDirection: 'row', alignItems: 'center', gap: Spacing[1],
+    paddingHorizontal: Spacing[4], paddingVertical: Spacing[2],
+    borderRadius: Radius.pill,
+  },
+  newBtnLabel: {
+    fontSize: FontSize.sm, fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.snug,
+  },
+  filterRow: { flexDirection: 'row', gap: Spacing[2] },
+  pill: {
+    paddingHorizontal: Spacing[3],
+    paddingVertical: Spacing[2],
+    borderRadius: Radius.pill,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  pillLabel: {
+    fontSize: FontSize.xs, fontWeight: FontWeight.bold,
+    letterSpacing: LetterSpacing.snug,
+  },
 });

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -7,20 +7,23 @@ import {
 import { Image } from 'expo-image';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useRouter } from 'expo-router';
+import { useRouter, router } from 'expo-router';
+import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/contexts/ToastContext';
 import BloodGroupBadge from '@/components/BloodGroupBadge';
 import ToggleSwitch from '@/components/ToggleSwitch';
 import SelectSheet from '@/components/SelectSheet';
 import Button from '@/components/Button';
-import { FontSize, FontWeight, Spacing, Radius, LetterSpacing } from '@/constants/Typography';
+import { FontSize, FontWeight, Spacing, Radius, LetterSpacing, TAB_BAR_BOTTOM_INSET } from '@/constants/Typography';
 import { BLOOD_GROUPS } from '@/constants/BloodData';
 import { formatDate, canDonateAgain } from '@/utils/helpers';
 
 export default function ProfileScreen() {
   const { theme, mode, setMode } = useTheme();
   const { profile, signOut, updateProfile } = useAuth();
+  const toast  = useToast();
   const insets = useSafeAreaInsets();
   const [saving, setSaving] = useState(false);
   const [themeSheet, setThemeSheet]  = useState(false);
@@ -29,16 +32,20 @@ export default function ProfileScreen() {
   const { canDonate, daysLeft } = canDonateAgain(profile?.last_donation_date ?? null);
 
   const toggle = useCallback(async (key: string, val: boolean) => {
+    Haptics.selectionAsync().catch(() => {});
     setSaving(true);
     try { await updateProfile({ [key]: val } as any); }
-    catch (e: any) { Alert.alert('Error', e.message); }
+    catch (e: any) {
+      toast.error("Couldn't update", { description: e?.message ?? 'Try again in a moment' });
+    }
     finally { setSaving(false); }
-  }, [updateProfile]);
+  }, [updateProfile, toast]);
 
   const handleSignOut = useCallback(() => {
-    Alert.alert('Sign Out', 'Are you sure?', [
+    Haptics.selectionAsync().catch(() => {});
+    Alert.alert('Sign out', 'Sign out of BludStack? You can sign back in any time with your email.', [
       { text: 'Cancel', style: 'cancel' },
-      { text: 'Sign Out', style: 'destructive', onPress: signOut },
+      { text: 'Sign out', style: 'destructive', onPress: signOut },
     ]);
   }, [signOut]);
 
@@ -58,11 +65,14 @@ export default function ProfileScreen() {
   return (
     <View style={[styles.root, { backgroundColor: theme.background }]}>
       <ScrollView
-        contentContainerStyle={{ paddingBottom: insets.bottom + Spacing[12] }}
+        contentContainerStyle={{ paddingBottom: TAB_BAR_BOTTOM_INSET + Spacing[4] }}
         showsVerticalScrollIndicator={false}
       >
         {/* ── Hero ── */}
         <View style={[styles.hero, { paddingTop: insets.top + Spacing[6], backgroundColor: theme.surface, borderBottomColor: theme.border }]}>
+          <Text style={[styles.sectionLabel, { color: theme.textMuted, marginBottom: Spacing[3] }]}>
+            Account · Profile
+          </Text>
           {/* Avatar */}
           <View style={[styles.avatarRing, { borderColor: statusColor }]}>
             {profile.avatar_url ? (
@@ -85,7 +95,10 @@ export default function ProfileScreen() {
             <View style={[styles.dot, { backgroundColor: statusColor }]} />
             <Text style={[styles.statusLabel, { color: statusColor }]}>{statusLabel}</Text>
             {profile.is_verified && (
-              <Text style={[styles.verified, { color: theme.success }]}>  ✓ Verified</Text>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, marginLeft: Spacing[2] }}>
+                <Ionicons name="checkmark-circle" size={14} color={theme.success} />
+                <Text style={[styles.verified, { color: theme.success }]}>Verified</Text>
+              </View>
             )}
           </View>
 
@@ -93,7 +106,7 @@ export default function ProfileScreen() {
           <View style={[styles.statsRow, { borderTopColor: theme.border }]}>
             <Stat label="DONATIONS"   value={profile.total_donations} color={theme.primary} theme={theme} />
             <View style={[styles.statSep, { backgroundColor: theme.border }]} />
-            <Stat label="LIVES HELPED" value={profile.total_donations * 3} color={theme.success} theme={theme} />
+            <Stat label="LIVES HELPED" value={profile.total_donations} color={theme.success} theme={theme} />
             <View style={[styles.statSep, { backgroundColor: theme.border }]} />
             <Stat label="LAST DONATED"
               value={profile.last_donation_date ? formatDate(profile.last_donation_date) : '—'}
@@ -116,17 +129,23 @@ export default function ProfileScreen() {
           <Text style={[styles.caret, { color: theme.textMuted }]}>›</Text>
         </TouchableOpacity>
 
-        {/* ── Donor settings ── */}
+        {/* ── Donor settings ──
+            Inner toggles render in 'inline' variant so they flush into the
+            parent card — nested rounded rectangles would compete for the eye.
+            A hairline divider separates the two rows. */}
         <SectionHeader label="DONOR SETTINGS" theme={theme} />
         <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
           <ToggleSwitch
+            variant="inline"
             label="Available to Donate"
             description="Receive alerts when someone nearby needs your blood group"
             value={profile.is_available_to_donate}
             onValueChange={v => toggle('is_available_to_donate', v)}
             disabled={saving || !canDonate}
           />
+          <View style={[styles.cardDivider, { backgroundColor: theme.divider }]} />
           <ToggleSwitch
+            variant="inline"
             label="Share Medical History"
             description="Let matched donors/recipients see your disclosed conditions"
             value={profile.share_medical_history}
@@ -154,6 +173,25 @@ export default function ProfileScreen() {
           </>
         )}
 
+        {/* ── Edit profile ── */}
+        <SectionHeader label="PROFILE" theme={theme} />
+        <TouchableOpacity
+          onPress={() => router.push('/profile/edit' as any)}
+          style={[styles.settingRow, { backgroundColor: theme.card, borderColor: theme.border }]}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel="Edit profile"
+        >
+          <Ionicons name="person-circle-outline" size={20} color={theme.textPrimary} />
+          <View style={{ flex: 1, marginLeft: Spacing[3] }}>
+            <Text style={[styles.rowTitle, { color: theme.textPrimary }]}>Edit profile</Text>
+            <Text style={[styles.rowSub, { color: theme.textMuted }]}>
+              Name, blood, role, contact, medical
+            </Text>
+          </View>
+          <Ionicons name="chevron-forward" size={18} color={theme.textMuted} />
+        </TouchableOpacity>
+
         {/* ── App settings ── */}
         <SectionHeader label="APP SETTINGS" theme={theme} />
         <TouchableOpacity
@@ -179,13 +217,13 @@ export default function ProfileScreen() {
         <SectionHeader label="ABOUT" theme={theme} />
         <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
           {[
-            { icon: 'ℹ️', label: 'Version', value: '1.0.0' },
-            { icon: '❤️', label: 'License', value: 'Free & Open Source' },
-            { icon: '🛡️', label: 'Security', value: 'Supabase RLS' },
-          ].map(({ icon, label, value }) => (
+            { iconName: 'information-circle-outline', label: 'Version',  value: '1.0.0' },
+            { iconName: 'heart-outline',              label: 'License',  value: 'Free and open source' },
+            { iconName: 'shield-checkmark-outline',   label: 'Security', value: 'Supabase RLS' },
+          ].map(({ iconName, label, value }) => (
             <View key={label} style={[styles.aboutRow, { borderBottomColor: theme.border }]}>
-              <Text style={styles.aboutIcon}>{icon}</Text>
-              <Text style={[styles.aboutLabel, { color: theme.textPrimary }]}>{label}</Text>
+              <Ionicons name={iconName as any} size={18} color={theme.textMuted} />
+              <Text style={[styles.aboutLabel, { color: theme.textPrimary, marginLeft: Spacing[3] }]}>{label}</Text>
               <Text style={[styles.aboutValue, { color: theme.textMuted }]}>{value}</Text>
             </View>
           ))}
@@ -249,6 +287,12 @@ const styles = StyleSheet.create({
   avatarFallback: { width: 80, height: 80, borderRadius: 40, alignItems: 'center', justifyContent: 'center' },
   initial:     { fontSize: FontSize['2xl'], fontWeight: FontWeight.black },
   heroName:    { fontSize: FontSize.xl, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.snug },
+  sectionLabel: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
+    textTransform: 'uppercase',
+  },
   heroEmail:   { fontSize: FontSize.sm, marginTop: -Spacing[2] },
   statusRow:   { flexDirection: 'row', alignItems: 'center', paddingHorizontal: Spacing[4], paddingVertical: Spacing[2], borderRadius: Radius.full, gap: Spacing[2] },
   dot:         { width: 7, height: 7, borderRadius: 4 },
@@ -257,14 +301,15 @@ const styles = StyleSheet.create({
   statsRow:    { flexDirection: 'row', alignItems: 'center', width: '100%', borderTopWidth: StyleSheet.hairlineWidth, paddingTop: Spacing[5], paddingHorizontal: Spacing[4] },
   statSep:     { width: StyleSheet.hairlineWidth, height: 32 },
   sectionHeader: { fontSize: FontSize['2xs'], fontWeight: FontWeight.black, letterSpacing: LetterSpacing.widest, textTransform: 'uppercase', paddingHorizontal: Spacing[5], paddingTop: Spacing[6], paddingBottom: Spacing[2] },
-  settingRow:  { flexDirection: 'row', alignItems: 'center', padding: Spacing[4], marginHorizontal: Spacing[5], borderRadius: Radius.sm, borderWidth: StyleSheet.hairlineWidth },
-  card:        { marginHorizontal: Spacing[5], borderRadius: Radius.sm, borderWidth: StyleSheet.hairlineWidth, paddingHorizontal: Spacing[4] },
+  settingRow:  { flexDirection: 'row', alignItems: 'center', padding: Spacing[4], marginHorizontal: Spacing[5], borderRadius: Radius.xl, borderWidth: StyleSheet.hairlineWidth },
+  card:        { marginHorizontal: Spacing[5], borderRadius: Radius.xl, borderWidth: StyleSheet.hairlineWidth, paddingHorizontal: Spacing[4] },
+  cardDivider: { height: StyleSheet.hairlineWidth, marginHorizontal: -Spacing[4] },
   rowTitle:    { fontSize: FontSize.base, fontWeight: FontWeight.medium },
   rowSub:      { fontSize: FontSize.xs, marginTop: 2 },
   caret:       { fontSize: FontSize.lg },
   medNote:     { fontSize: FontSize.xs, paddingVertical: Spacing[3] },
   tags:        { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing[2], paddingBottom: Spacing[3] },
-  tag:         { paddingHorizontal: Spacing[2], paddingVertical: 3, borderRadius: Radius.xs },
+  tag:         { paddingHorizontal: Spacing[2], paddingVertical: 3, borderRadius: Radius.pill },
   tagText:     { fontSize: FontSize.xs },
   aboutRow:    { flexDirection: 'row', alignItems: 'center', paddingVertical: Spacing[4], borderBottomWidth: StyleSheet.hairlineWidth, gap: Spacing[3] },
   aboutIcon:   { fontSize: 18 },

--- a/mobile/app/(tabs)/request.tsx
+++ b/mobile/app/(tabs)/request.tsx
@@ -1,264 +1,1048 @@
 // app/(tabs)/request.tsx
-import React, { useState, useCallback } from 'react';
+// Lever: DECIDE -> VERIFY -> ACT. Uber's ride-request pattern, blood-app remix.
+//
+//   DECIDE  Map dominates ~55% — oversized hospital pin + pulsing crimson
+//           dots showing compatible available donors near the pin. Motion =
+//           perceived availability. Live donor-count badge in the corner.
+//
+//   VERIFY  Bottom sheet rises with spring on mount (peak-end on entry).
+//           Crimson accent strip above the handle for brand presence.
+//           Route summary bar (your location -> hospital) with the actual
+//           reverse-geocoded address so the user catches wrong pins before
+//           committing. Horizontal urgency carousel — cards spring-scale on
+//           select. 2x4 blood group grid (tap-friendly Fitts's Law). Compact
+//           units stepper with a visible dot row. Preview card showing what
+//           a donor will see — last sanity check before commit (verification
+//           reduces post-booking cancellations).
+//
+//   ACT     Sticky full-width pill above the tab bar, label mirrors urgency
+//           tier ("Post critical request"). When urgency is critical the
+//           button breathes — subtle loss-aversion via motion. Haptic
+//           medium-impact on tap. Always one tap away.
+//
+// Role-aware: only renders for recipients and 'both'. Donor-only users
+// never see this tab.
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  View, Text, ScrollView, KeyboardAvoidingView,
-  Platform, StyleSheet, TouchableOpacity, Alert, useWindowDimensions,
+  KeyboardAvoidingView, Platform, Pressable, ScrollView, StyleSheet, Text, View,
+  useWindowDimensions,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
+import MapView, { Marker, PROVIDER_DEFAULT, type Region } from 'react-native-maps';
+import * as Location from 'expo-location';
+import * as Haptics from 'expo-haptics';
+import Animated, {
+  useAnimatedStyle, useSharedValue, withRepeat, withTiming, withSpring,
+  withSequence, interpolate, Easing, runOnJS,
+} from 'react-native-reanimated';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { useLocation } from '@/hooks/useLocation';
 import { useMyRequests } from '@/hooks/useRequests';
+import { useToast } from '@/contexts/ToastContext';
 import Button from '@/components/Button';
 import Input from '@/components/Input';
 import BloodGroupBadge from '@/components/BloodGroupBadge';
-import { FontSize, FontWeight, Spacing, Radius, LetterSpacing } from '@/constants/Typography';
 import {
-  BLOOD_GROUPS, URGENCY_CONFIG, URGENCY_LEVELS,
-  BloodGroup, UrgencyLevel,
+  BLOOD_GROUPS, URGENCY_LEVELS, type BloodGroup, type UrgencyLevel,
 } from '@/constants/BloodData';
+import {
+  FontSize, FontWeight, LetterSpacing, Spacing, Radius, Elevation, Motion,
+  TAB_BAR_HEIGHT,
+} from '@/constants/Typography';
+import { deltaFromKm, formatDistance } from '@/utils/geo';
+import { apiNearbyDonors } from '@/utils/api';
+import { errorReporter } from '@/lib/errorReporter';
 
-const URGENCY_COLORS = { critical: '#E8002D', urgent: '#F5A623', standard: '#00A651' };
+// ────────────────────────────────────────────────────────────────────────────
+// Urgency meta — drives carousel cards, copy, and the dynamic CTA label.
+// ────────────────────────────────────────────────────────────────────────────
+const URGENCY_META: Record<UrgencyLevel, {
+  label: string;
+  windowLabel: string;
+  sub: string;
+  iconName: keyof typeof Ionicons.glyphMap;
+}> = {
+  critical: { label: 'Critical', windowLabel: 'in 30 min', sub: 'Alarm-tone alert · bypasses silent mode', iconName: 'flash'            },
+  urgent:   { label: 'Urgent',   windowLabel: 'in 2 hrs',  sub: 'Heads-up notification, no alarm',         iconName: 'time'             },
+  standard: { label: 'Standard', windowLabel: 'today',     sub: 'Standard notification',                   iconName: 'calendar-outline' },
+};
 
+// ────────────────────────────────────────────────────────────────────────────
+// Pulsing-dot for live donors — Reanimated worklet, UI thread, 120fps-safe.
+// ────────────────────────────────────────────────────────────────────────────
+const PulseDot = React.memo(function PulseDot({ color }: { color: string }) {
+  const progress = useSharedValue(0);
+  useEffect(() => {
+    progress.value = withRepeat(
+      withTiming(1, { duration: 2400, easing: Easing.inOut(Easing.ease) }),
+      -1, false,
+    );
+  }, [progress]);
+  const ringStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: interpolate(progress.value, [0, 1], [0.6, 2.4]) }],
+    opacity:   interpolate(progress.value, [0, 0.6, 1], [0.45, 0.2, 0]),
+  }));
+  return (
+    <View style={pulseStyles.wrap}>
+      <Animated.View style={[pulseStyles.ring, { backgroundColor: color }, ringStyle]} />
+      <View style={[pulseStyles.dot, { backgroundColor: color }]} />
+    </View>
+  );
+});
+const pulseStyles = StyleSheet.create({
+  wrap: { width: 28, height: 28, alignItems: 'center', justifyContent: 'center' },
+  ring: { position: 'absolute', width: 24, height: 24, borderRadius: 12 },
+  dot:  { width: 10, height: 10, borderRadius: 5, borderWidth: 1.5, borderColor: '#FFFFFF' },
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tactile urgency card — scales 1.04× on select with spring physics.
+// ────────────────────────────────────────────────────────────────────────────
+const UrgencyCard = React.memo(function UrgencyCard({
+  level, selected, onPress, theme,
+}: {
+  level: UrgencyLevel; selected: boolean; onPress: () => void; theme: any;
+}) {
+  const scale = useSharedValue(selected ? 1.04 : 1);
+  useEffect(() => {
+    scale.value = withSpring(selected ? 1.04 : 1, Motion.spring.snappy);
+  }, [selected, scale]);
+  const aStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
+
+  const meta = URGENCY_META[level];
+  const bg   = selected ? theme.primary       : theme.cardElevated;
+  const fg   = selected ? theme.textOnPrimary : theme.textPrimary;
+  const sub  = selected ? theme.textOnPrimary : theme.textMuted;
+
+  return (
+    <Animated.View style={aStyle}>
+      <Pressable
+        onPress={() => {
+          Haptics.selectionAsync().catch(() => {});
+          onPress();
+        }}
+        style={[
+          urgencyStyles.card,
+          { backgroundColor: bg, borderColor: selected ? theme.primary : theme.border },
+          selected && Elevation.sm,
+        ]}
+        accessibilityRole="radio"
+        accessibilityState={{ selected }}
+        accessibilityLabel={`${meta.label} urgency, ${meta.windowLabel}`}
+      >
+        <View
+          style={[
+            urgencyStyles.iconWrap,
+            { backgroundColor: selected ? 'rgba(255,255,255,0.18)' : theme.surface },
+          ]}
+        >
+          <Ionicons name={meta.iconName} size={18} color={fg} />
+        </View>
+        <Text style={[urgencyStyles.label, { color: fg }]}>{meta.label}</Text>
+        <Text style={[urgencyStyles.window, { color: sub }]}>{meta.windowLabel}</Text>
+      </Pressable>
+    </Animated.View>
+  );
+});
+const urgencyStyles = StyleSheet.create({
+  card: {
+    width: 132,
+    paddingVertical: Spacing[3],
+    paddingHorizontal: Spacing[3],
+    borderRadius: Radius.xl,
+    borderWidth: 1.5,
+    alignItems: 'flex-start',
+    gap: Spacing[2],
+    marginRight: Spacing[3],
+  },
+  iconWrap: {
+    width: 36, height: 36, borderRadius: Radius.pill,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  label:  { fontSize: FontSize.base, fontWeight: FontWeight.black,    letterSpacing: LetterSpacing.snug },
+  window: { fontSize: FontSize.xs,   fontWeight: FontWeight.semibold, letterSpacing: LetterSpacing.snug },
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Smooth count-up label — animates the live-donor count when it changes.
+// ────────────────────────────────────────────────────────────────────────────
+function useCountUp(target: number, duration = 600) {
+  const [display, setDisplay] = useState(target);
+  const fromRef = useRef(target);
+  const tweenRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => {
+    const from = fromRef.current;
+    if (from === target) return;
+    const steps = Math.min(Math.abs(target - from), 30);
+    const stepMs = Math.max(16, duration / Math.max(steps, 1));
+    let i = 0;
+    if (tweenRef.current) clearInterval(tweenRef.current);
+    tweenRef.current = setInterval(() => {
+      i++;
+      const ratio = i / steps;
+      const v = Math.round(from + (target - from) * ratio);
+      setDisplay(v);
+      if (i >= steps) {
+        if (tweenRef.current) clearInterval(tweenRef.current);
+        fromRef.current = target;
+      }
+    }, stepMs);
+    return () => { if (tweenRef.current) clearInterval(tweenRef.current); };
+  }, [target, duration]);
+  return display;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Breathing wrapper for the CTA when urgency is critical (loss-aversion motion)
+// ────────────────────────────────────────────────────────────────────────────
+const BreathingWrapper = React.memo(function BreathingWrapper({
+  enabled, children,
+}: { enabled: boolean; children: React.ReactNode }) {
+  const breath = useSharedValue(1);
+  useEffect(() => {
+    if (enabled) {
+      breath.value = withRepeat(
+        withSequence(
+          withTiming(1.02, { duration: 900, easing: Easing.inOut(Easing.ease) }),
+          withTiming(1.00, { duration: 900, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1, false,
+      );
+    } else {
+      breath.value = withTiming(1, { duration: Motion.duration.fast });
+    }
+  }, [enabled, breath]);
+  const aStyle = useAnimatedStyle(() => ({ transform: [{ scale: breath.value }] }));
+  return <Animated.View style={aStyle}>{children}</Animated.View>;
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Bottom-sheet entrance — slides up with spring on mount.
+// ────────────────────────────────────────────────────────────────────────────
+function useSheetEntrance() {
+  const offset  = useSharedValue(60);
+  const opacity = useSharedValue(0);
+  useEffect(() => {
+    offset.value  = withSpring(0, Motion.spring.soft);
+    opacity.value = withTiming(1, { duration: Motion.duration.base });
+  }, [offset, opacity]);
+  return useAnimatedStyle(() => ({
+    transform: [{ translateY: offset.value }],
+    opacity:   opacity.value,
+  }));
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helper — friendly relative-distance string for the live badge.
+// ────────────────────────────────────────────────────────────────────────────
+function distanceWord(count: number, avgKm: number | null): string {
+  if (count === 0) return 'Searching…';
+  if (avgKm == null || !isFinite(avgKm)) return `${count} ready`;
+  return `${count} within ${formatDistance(avgKm)}`;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// The screen
+// ────────────────────────────────────────────────────────────────────────────
 export default function RequestScreen() {
-  const { theme } = useTheme();
+  const { theme, isDark } = useTheme();
   const { profile } = useAuth();
-  const router   = useRouter();
-  const insets   = useSafeAreaInsets();
+  const router  = useRouter();
+  const toast   = useToast();
+  const insets  = useSafeAreaInsets();
+  const { height } = useWindowDimensions();
 
-  const { location, address, refreshLocation, loading: locLoading } = useLocation(true);
+  const { location, refreshLocation } = useLocation(true);
   const { createRequest } = useMyRequests();
 
+  // Form state
   const [bloodGroup, setBloodGroup] = useState<BloodGroup>(
-    (profile?.blood_group as BloodGroup) ?? 'O+'
+    (profile?.blood_group as BloodGroup) ?? 'O+',
   );
-  const [urgency, setUrgency]       = useState<UrgencyLevel>('urgent');
-  const [units, setUnits]           = useState('1');
-  const [hospital, setHospital]     = useState('');
-  const [hospAddr, setHospAddr]     = useState('');
-  const [notes, setNotes]           = useState('');
-  const [loading, setLoading]       = useState(false);
+  const [urgency, setUrgency] = useState<UrgencyLevel>('urgent');
+  const [units, setUnits]     = useState(1);
+  const [hospital, setHospital] = useState('');
+  const [hospAddr, setHospAddr] = useState('');
+  const [notes, setNotes]       = useState('');
+  const [loading, setLoading]   = useState(false);
 
-  const submit = useCallback(async () => {
-    if (!hospital.trim()) { Alert.alert('Required', 'Enter the hospital name'); return; }
-    if (!hospAddr.trim()) { Alert.alert('Required', 'Enter the hospital address'); return; }
-    if (!location) {
-      Alert.alert('Location needed', 'Allow location access so donors can find you.');
-      refreshLocation(); return;
+  // Pin + reverse geocoding
+  const mapRef = useRef<MapView | null>(null);
+  const [pin, setPin] = useState<{ latitude: number; longitude: number } | null>(null);
+  const [geoLoading, setGeoLoading] = useState(false);
+  const [userAddress, setUserAddress] = useState<string | null>(null);
+
+  // Live donor data
+  const [nearbyDonors, setNearbyDonors] = useState<Array<{ id: string; lat: number; lon: number; distanceKm: number }>>([]);
+  const donorCount = nearbyDonors.length;
+  const animatedDonorCount = useCountUp(donorCount);
+  const avgDonorKm = useMemo(() => {
+    if (donorCount === 0) return null;
+    return nearbyDonors.reduce((s, d) => s + (d.distanceKm ?? 0), 0) / donorCount;
+  }, [nearbyDonors, donorCount]);
+
+  // Center map on user once we have their location
+  useEffect(() => {
+    if (location && !pin) {
+      setPin({ latitude: location.latitude, longitude: location.longitude });
     }
+  }, [location, pin]);
+
+  // Reverse-geocode the user's location once (for the route bar's "from" line)
+  useEffect(() => {
+    if (!location || userAddress) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const results = await Location.reverseGeocodeAsync(location);
+        if (cancelled) return;
+        const r = results?.[0];
+        if (r) {
+          const parts = [r.district ?? r.subregion, r.city].filter(Boolean);
+          setUserAddress(parts.join(', ') || 'Your current location');
+        } else {
+          setUserAddress('Your current location');
+        }
+      } catch { setUserAddress('Your current location'); }
+    })();
+    return () => { cancelled = true; };
+  }, [location, userAddress]);
+
+  // Reverse-geocode the pin → hospital address (auto-fill)
+  useEffect(() => {
+    if (!pin) return;
+    let cancelled = false;
+    (async () => {
+      setGeoLoading(true);
+      try {
+        const results = await Location.reverseGeocodeAsync(pin);
+        if (cancelled) return;
+        const r = results?.[0];
+        if (r) {
+          const parts = [r.street, r.district, r.city, r.region].filter(Boolean);
+          if (parts.length > 0) setHospAddr(parts.join(', '));
+        }
+      } catch { /* address is non-critical */ }
+      finally { if (!cancelled) setGeoLoading(false); }
+    })();
+    return () => { cancelled = true; };
+  }, [pin?.latitude, pin?.longitude]);
+
+  // Live donor query — distance only (privacy). Jitter for display.
+  useEffect(() => {
+    if (!pin) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await apiNearbyDonors({
+          lat: pin.latitude, lon: pin.longitude, radiusKm: 25, bloodGroup,
+        });
+        if (cancelled) return;
+        const donorsRaw = (resp?.donors ?? []) as Array<{ id: string; distanceKm: number }>;
+        const dots = donorsRaw.slice(0, 8).map((d, idx) => {
+          const angle = (idx / Math.max(donorsRaw.length, 1)) * 2 * Math.PI;
+          const km    = Math.max(0.3, Math.min(d.distanceKm, 12));
+          const dLat  = (km / 111) * Math.sin(angle);
+          const dLon  = (km / (111 * Math.cos((pin.latitude * Math.PI) / 180))) * Math.cos(angle);
+          return { id: d.id, lat: pin.latitude + dLat, lon: pin.longitude + dLon, distanceKm: d.distanceKm };
+        });
+        setNearbyDonors(dots);
+      } catch (e: any) {
+        errorReporter.warn('Could not fetch nearby donors for map', { msg: e?.message });
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [pin?.latitude, pin?.longitude, bloodGroup]);
+
+  // Map interactions
+  const onMapPress = useCallback((e: any) => {
+    const { latitude, longitude } = e.nativeEvent.coordinate;
+    Haptics.selectionAsync().catch(() => {});
+    setPin({ latitude, longitude });
+  }, []);
+  const onRecentre = useCallback(async () => {
+    await refreshLocation();
+    if (location && mapRef.current) {
+      mapRef.current.animateToRegion(
+        { latitude: location.latitude, longitude: location.longitude,
+          latitudeDelta: deltaFromKm(1), longitudeDelta: deltaFromKm(1) },
+        Motion.duration.base,
+      );
+      setPin({ latitude: location.latitude, longitude: location.longitude });
+    }
+  }, [refreshLocation, location]);
+
+  // Submit
+  const submit = useCallback(async () => {
+    if (!pin) {
+      toast.error('Pin the hospital location', { description: 'Tap the map to set where you need blood.' });
+      return;
+    }
+    if (!hospital.trim()) { toast.error('Hospital name is required'); return; }
+    if (!hospAddr.trim()) { toast.error('Hospital address is required'); return; }
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
     setLoading(true);
     try {
-      const req = await createRequest({
-        blood_group: bloodGroup, urgency,
-        units_needed: parseInt(units, 10) || 1,
-        hospital_name: hospital.trim(),
-        hospital_address: hospAddr.trim(),
-        latitude: location.latitude,
-        longitude: location.longitude,
+      const req: any = await createRequest({
+        blood_group: bloodGroup, urgency, units_needed: units,
+        hospital_name: hospital.trim(), hospital_address: hospAddr.trim(),
+        latitude: pin.latitude, longitude: pin.longitude,
         notes: notes.trim() || undefined,
       });
-      Alert.alert(
-        'Request Posted',
-        'Notifying compatible donors in your area now.',
-        [{ text: 'View Request', onPress: () => router.push(`/request/${req.id}`) }]
-      );
-      setHospital(''); setHospAddr(''); setNotes(''); setUnits('1');
+      toast.success('Request posted', { description: 'Notifying compatible donors near the hospital.' });
+      setHospital(''); setHospAddr(''); setNotes(''); setUnits(1);
+      if (req?.id) router.push(`/request/${req.id}` as any);
     } catch (e: any) {
-      Alert.alert('Error', e.message ?? 'Failed to post. Try again.');
-    } finally {
-      setLoading(false);
-    }
-  }, [bloodGroup, urgency, units, hospital, hospAddr, notes, location, createRequest, refreshLocation, router]);
+      errorReporter.error(e, { screen: 'tabs/request' });
+      toast.error("Couldn't post the request", { description: e?.message ?? 'Try again.' });
+    } finally { setLoading(false); }
+  }, [pin, hospital, hospAddr, bloodGroup, urgency, units, notes, createRequest, toast, router]);
+
+  // Initial region
+  const initialRegion: Region | undefined = pin
+    ? { ...pin, latitudeDelta: deltaFromKm(2), longitudeDelta: deltaFromKm(2) }
+    : location
+      ? { latitude: location.latitude, longitude: location.longitude,
+          latitudeDelta: deltaFromKm(2), longitudeDelta: deltaFromKm(2) }
+      : undefined;
+
+  const submitDisabled = !pin || !hospital.trim() || !hospAddr.trim() || loading;
+  const ctaLabel = useMemo(() => {
+    if (urgency === 'critical') return 'Post critical request';
+    if (urgency === 'urgent')   return 'Post urgent request';
+    return 'Post request';
+  }, [urgency]);
+  // Accent color for the CTA dock summary row mirrors the urgency tier so the
+  // user catches "critical = red" / "urgent = amber" before committing.
+  const ctaAccent =
+    urgency === 'critical' ? theme.danger
+    : urgency === 'urgent'  ? theme.warning
+    :                          theme.success;
+
+  // Map height ~55% of viewport (Uber's ~60% spec, leaves enough for verify)
+  const mapHeight = Math.max(280, Math.round(height * 0.55));
+
+  // Sheet entrance animation
+  const sheetEntrance = useSheetEntrance();
 
   return (
     <KeyboardAvoidingView
       style={[styles.root, { backgroundColor: theme.background }]}
-      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
-      {/* Header */}
-      <View style={[styles.topBar, { paddingTop: insets.top + Spacing[4], borderBottomColor: theme.border, backgroundColor: theme.surface }]}>
-        <Text style={[styles.pageTitle, { color: theme.textPrimary }]}>New Request</Text>
-        <Text style={[styles.pageSubtitle, { color: theme.textMuted }]}>
-          We'll find donors within 50 km
-        </Text>
-      </View>
-
-      <ScrollView
-        contentContainerStyle={[styles.scroll, { paddingBottom: insets.bottom + Spacing[10] }]}
-        showsVerticalScrollIndicator={false}
-        keyboardShouldPersistTaps="handled"
-      >
-        {/* Blood Group */}
-        <Section label="Blood Group Needed" theme={theme}>
-          <View style={styles.bloodGrid}>
-            {BLOOD_GROUPS.map(bg => (
-              <TouchableOpacity
-                key={bg}
-                onPress={() => setBloodGroup(bg)}
-                activeOpacity={0.7}
-                style={[styles.bloodBtn, {
-                  borderColor:     bloodGroup === bg ? theme.primary : theme.border,
-                  backgroundColor: bloodGroup === bg ? theme.primaryMuted : theme.card,
-                  borderWidth:     bloodGroup === bg ? 2 : StyleSheet.hairlineWidth,
-                }]}
+      {/* ───────────────────────── MAP (DECIDE) ─────────────────────────── */}
+      <View style={[styles.mapWrap, { height: mapHeight }]}>
+        {initialRegion && (
+          <MapView
+            ref={mapRef}
+            style={StyleSheet.absoluteFill}
+            provider={PROVIDER_DEFAULT}
+            userInterfaceStyle={isDark ? 'dark' : 'light'}
+            initialRegion={initialRegion}
+            onPress={onMapPress}
+            onLongPress={onMapPress}
+            showsUserLocation
+            showsMyLocationButton={false}
+          >
+            {/* Pulsing donor dots — proof of liveness */}
+            {nearbyDonors.map(d => (
+              <Marker
+                key={d.id}
+                coordinate={{ latitude: d.lat, longitude: d.lon }}
+                anchor={{ x: 0.5, y: 0.5 }}
+                tracksViewChanges={false}
               >
-                <BloodGroupBadge bloodGroup={bg} size="md" inverted={bloodGroup === bg} />
-              </TouchableOpacity>
+                <PulseDot color={theme.primary} />
+              </Marker>
             ))}
-          </View>
-        </Section>
-
-        {/* Urgency */}
-        <Section label="Urgency Level" theme={theme}>
-          <View style={styles.urgencyRow}>
-            {URGENCY_LEVELS.map(u => {
-              const cfg   = URGENCY_CONFIG[u];
-              const color = URGENCY_COLORS[u];
-              const active = urgency === u;
-              return (
-                <TouchableOpacity
-                  key={u}
-                  onPress={() => setUrgency(u)}
-                  activeOpacity={0.7}
-                  style={[styles.urgencyBtn, {
-                    borderColor:     active ? color : theme.border,
-                    backgroundColor: active ? `${color}12` : theme.card,
-                    borderWidth:     active ? 2 : StyleSheet.hairlineWidth,
-                  }]}
-                >
-                  <Text style={styles.urgencyIcon}>{cfg.icon}</Text>
-                  <Text style={[styles.urgencyLabel, { color: active ? color : theme.textSecondary }]}>
-                    {cfg.label}
-                  </Text>
-                </TouchableOpacity>
-              );
-            })}
-          </View>
-        </Section>
-
-        {/* Units */}
-        <Section label="Units Required" theme={theme}>
-          <View style={styles.unitsRow}>
-            {['1','2','3','4','5'].map(n => (
-              <TouchableOpacity
-                key={n}
-                onPress={() => setUnits(n)}
-                activeOpacity={0.7}
-                style={[styles.unitBtn, {
-                  borderColor:     units === n ? theme.textPrimary : theme.border,
-                  backgroundColor: units === n ? theme.textPrimary : theme.card,
-                  borderWidth:     units === n ? 2 : StyleSheet.hairlineWidth,
-                }]}
+            {/* Oversized hospital pin (Uber: ambiguity = cancellations) */}
+            {pin && (
+              <Marker
+                coordinate={pin}
+                draggable
+                anchor={{ x: 0.5, y: 1 }}
+                onDragEnd={e => {
+                  const { latitude, longitude } = e.nativeEvent.coordinate;
+                  Haptics.selectionAsync().catch(() => {});
+                  setPin({ latitude, longitude });
+                }}
               >
-                <Text style={[styles.unitLabel, { color: units === n ? theme.textInverse : theme.textSecondary }]}>
-                  {n}
-                </Text>
-              </TouchableOpacity>
-            ))}
+                <View style={[styles.bigPin, { backgroundColor: theme.primary, borderColor: theme.surface }]}>
+                  <Ionicons name="medical" size={18} color={theme.textOnPrimary} />
+                </View>
+              </Marker>
+            )}
+          </MapView>
+        )}
+
+        {/* Top-right recenter pill */}
+        <View pointerEvents="box-none" style={[styles.mapTop, { top: insets.top + Spacing[3] }]}>
+          <View style={{ flex: 1 }} />
+          <Pressable
+            onPress={onRecentre}
+            style={({ pressed }) => [
+              styles.recentreBtn,
+              { backgroundColor: theme.surface, borderColor: theme.border, opacity: pressed ? 0.92 : 1 },
+              Elevation.md,
+            ]}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel="Recenter on my location"
+          >
+            <Ionicons name="locate" size={18} color={theme.textPrimary} />
+          </Pressable>
+        </View>
+
+        {/* Live donor count badge (replaces Uber's ETA pill).
+            bottom = Spacing[10] (40) so the pill clears the sheet's
+            -Spacing[5] (-20) overlap with ~20px of clean breathing room
+            above the sheet's rounded top edge. */}
+        {pin && (
+          <View
+            pointerEvents="none"
+            style={[
+              styles.donorBadge,
+              { backgroundColor: theme.surface, borderColor: theme.border, bottom: Spacing[10], left: Spacing[4] },
+              Elevation.md,
+            ]}
+          >
+            <View style={styles.liveDotWrap}>
+              <View style={[styles.liveDotOuter, { backgroundColor: theme.success + '40' }]} />
+              <View style={[styles.liveDot, { backgroundColor: theme.success }]} />
+            </View>
+            <View>
+              <Text style={[styles.donorBadgeNumber, { color: theme.textPrimary }]}>
+                {animatedDonorCount} {bloodGroup}
+              </Text>
+              <Text style={[styles.donorBadgeSub, { color: theme.textMuted }]}>
+                {distanceWord(donorCount, avgDonorKm)}
+              </Text>
+            </View>
           </View>
-        </Section>
+        )}
 
-        {/* Hospital */}
-        <Section label="Hospital Details" theme={theme}>
-          <Input
-            placeholder="Hospital name"
-            value={hospital}
-            onChangeText={setHospital}
-            returnKeyType="next"
-            leftIcon={<Ionicons name="medical-outline" size={18} color="#9C9890" />}
-            containerStyle={{ marginBottom: Spacing[3] }}
-          />
-          <Input
-            placeholder="Hospital address"
-            value={hospAddr}
-            onChangeText={setHospAddr}
-            leftIcon={<Text>📍</Text>}
-            containerStyle={{ marginBottom: Spacing[3] }}
-            multiline
-            numberOfLines={2}
-          />
-          <Input
-            placeholder="Additional notes (optional)"
-            value={notes}
-            onChangeText={setNotes}
-            multiline
-            numberOfLines={3}
-          />
-        </Section>
-
-        {/* Location */}
-        <TouchableOpacity
-          onPress={refreshLocation}
-          style={[styles.locRow, {
-            backgroundColor: theme.card, borderColor: location ? theme.success : theme.border,
-          }]}
-          activeOpacity={0.7}
+        {/* Bottom-right hint pill — matches donor badge bottom offset so
+            both pills align on the same visual baseline above the sheet. */}
+        <View
+          pointerEvents="none"
+          style={[
+            styles.mapHint,
+            { backgroundColor: theme.surface, borderColor: theme.border, bottom: Spacing[10], right: Spacing[4] },
+            Elevation.sm,
+          ]}
         >
-          <View style={[styles.locIcon, { backgroundColor: location ? theme.successMuted : theme.cardElevated }]}>
-            <Text style={{ fontSize: 18 }}>{location ? '📍' : '🔍'}</Text>
-          </View>
-          <View style={{ flex: 1 }}>
-            <Text style={[styles.locTitle, { color: theme.textPrimary }]}>
-              {location ? 'Location detected' : 'Detect location'}
-            </Text>
-            <Text style={[styles.locSub, { color: theme.textSecondary }]} numberOfLines={1}>
-              {address ?? (locLoading ? 'Finding your location…' : 'Tap to enable')}
-            </Text>
-          </View>
-          {location && <Text style={{ color: theme.success, fontWeight: FontWeight.bold }}>✓</Text>}
-        </TouchableOpacity>
-
-        {/* CTA */}
-        <View style={styles.ctaWrap}>
-          <Button
-            label={`Post ${URGENCY_CONFIG[urgency].icon} ${URGENCY_CONFIG[urgency].label} Request`}
-            variant="primary"
-            size="lg"
-            onPress={submit}
-            loading={loading}
-            fullWidth
-          />
-          <Text style={[styles.privacyNote, { color: theme.textMuted }]}>
-            🔒  Only blood group and hospital location are shared until a donor accepts.
+          <Ionicons name="hand-left-outline" size={14} color={theme.textMuted} />
+          <Text style={[styles.mapHintText, { color: theme.textMuted }]} numberOfLines={1}>
+            {pin ? 'Tap to move pin' : 'Tap to drop pin'}
           </Text>
         </View>
-      </ScrollView>
+      </View>
+
+      {/* ─────────────────────── BOTTOM SHEET (VERIFY) ───────────────────── */}
+      <Animated.View
+        style={[
+          styles.sheet,
+          {
+            backgroundColor: theme.surface,
+            borderTopColor: theme.border,
+            marginTop: -Spacing[5],
+          },
+          Elevation.lg,
+          sheetEntrance,
+        ]}
+      >
+        {/* Brand accent strip + handle (peak-end on first appear) */}
+        <View style={styles.sheetTop}>
+          <View style={[styles.accentStrip, { backgroundColor: theme.primary }]} />
+          <View style={[styles.handle, { backgroundColor: theme.borderStrong }]} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={{
+            paddingHorizontal: Spacing[5],
+            paddingBottom: insets.bottom + TAB_BAR_HEIGHT + Spacing[6],
+            gap: Spacing[5],
+          }}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* ── Route summary bar ─────────────────────────────────────── */}
+          <View style={[styles.routeBar, { backgroundColor: theme.cardElevated, borderColor: theme.border }]}>
+            <View style={styles.routeCol}>
+              <View style={[styles.routeDot, { backgroundColor: theme.success, borderColor: theme.surface }]} />
+              <View style={[styles.routeLine, { backgroundColor: theme.border }]} />
+              <View style={[styles.routeDot, { backgroundColor: theme.primary, borderColor: theme.surface }]} />
+            </View>
+            <View style={{ flex: 1, gap: Spacing[3] }}>
+              <View>
+                <Text style={[styles.routeLabel, { color: theme.textMuted }]}>You</Text>
+                <Text style={[styles.routeValue, { color: theme.textPrimary }]} numberOfLines={1}>
+                  {userAddress ?? 'Locating you…'}
+                </Text>
+              </View>
+              <View>
+                <Text style={[styles.routeLabel, { color: theme.textMuted }]}>Hospital</Text>
+                <Text style={[styles.routeValue, { color: theme.textPrimary }]} numberOfLines={1}>
+                  {hospital.trim() || hospAddr || (geoLoading ? 'Reading from pin…' : 'Tap the map to pin')}
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          {/* ── Urgency carousel ─────────────────────────────────────── */}
+          <View>
+            <SectionLabel theme={theme}>How urgent?</SectionLabel>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={{ paddingVertical: Spacing[1], paddingRight: Spacing[3] }}
+            >
+              {URGENCY_LEVELS.map(u => (
+                <UrgencyCard key={u} level={u} selected={urgency === u} onPress={() => setUrgency(u)} theme={theme} />
+              ))}
+            </ScrollView>
+            <Text style={[styles.urgencySub, { color: theme.textMuted }]} numberOfLines={2}>
+              {URGENCY_META[urgency].sub}
+            </Text>
+          </View>
+
+          {/* ── Blood group as 4×2 grid (tap-friendly Fitts) ─────────── */}
+          <View>
+            <SectionLabel theme={theme}>Blood group needed</SectionLabel>
+            <View style={styles.bloodGrid}>
+              {BLOOD_GROUPS.map(g => {
+                const selected = bloodGroup === g;
+                return (
+                  <Pressable
+                    key={g}
+                    onPress={() => {
+                      Haptics.selectionAsync().catch(() => {});
+                      setBloodGroup(g);
+                    }}
+                    style={[
+                      styles.bloodCell,
+                      {
+                        borderColor: selected ? theme.primary : theme.border,
+                        backgroundColor: selected ? theme.primary : theme.cardElevated,
+                      },
+                      selected && Elevation.sm,
+                    ]}
+                    accessibilityRole="radio"
+                    accessibilityState={{ selected }}
+                    accessibilityLabel={`Blood group ${g}`}
+                  >
+                    <Text style={[
+                      styles.bloodCellLabel,
+                      { color: selected ? theme.textOnPrimary : theme.textPrimary },
+                    ]}>{g}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
+
+          {/* ── Units (compact, with dot-row) ────────────────────────── */}
+          <View>
+            <SectionLabel theme={theme}>Units needed</SectionLabel>
+            <View style={[styles.unitsWrap, { backgroundColor: theme.cardElevated, borderColor: theme.border }]}>
+              <Pressable
+                onPress={() => {
+                  Haptics.selectionAsync().catch(() => {});
+                  setUnits(u => Math.max(1, u - 1));
+                }}
+                style={[styles.unitsBtn, { borderRightColor: theme.border }]}
+                disabled={units <= 1}
+                accessibilityRole="button"
+                accessibilityLabel="Decrease units"
+              >
+                <Ionicons name="remove" size={20} color={units <= 1 ? theme.textTertiary : theme.textPrimary} />
+              </Pressable>
+              <View style={styles.unitsCenter}>
+                <Text style={[styles.unitsValue, { color: theme.textPrimary }]}>{units}</Text>
+                <View style={styles.unitsDots}>
+                  {Array.from({ length: Math.min(units, 8) }).map((_, i) => (
+                    <View key={i} style={[styles.unitsDot, { backgroundColor: theme.primary }]} />
+                  ))}
+                  {units > 8 && <Text style={[styles.unitsMore, { color: theme.textMuted }]}>+{units - 8}</Text>}
+                </View>
+                <Text style={[styles.unitsLabel, { color: theme.textMuted }]}>
+                  {units === 1 ? '1 donor will be matched' : `${units} donors will be matched`}
+                </Text>
+              </View>
+              <Pressable
+                onPress={() => {
+                  Haptics.selectionAsync().catch(() => {});
+                  setUnits(u => Math.min(20, u + 1));
+                }}
+                style={[styles.unitsBtn, { borderLeftColor: theme.border }]}
+                disabled={units >= 20}
+                accessibilityRole="button"
+                accessibilityLabel="Increase units"
+              >
+                <Ionicons name="add" size={20} color={units >= 20 ? theme.textTertiary : theme.textPrimary} />
+              </Pressable>
+            </View>
+          </View>
+
+          {/* ── Hospital details ─────────────────────────────────────── */}
+          <View style={{ gap: Spacing[3] }}>
+            <SectionLabel theme={theme}>Confirm the hospital</SectionLabel>
+            <Input
+              label="Hospital name"
+              placeholder="e.g. Services Hospital"
+              value={hospital}
+              onChangeText={setHospital}
+              leftIcon={<Ionicons name="medical-outline" size={18} color={theme.textMuted} />}
+            />
+            <Input
+              label="Address"
+              placeholder={geoLoading ? 'Reading address from pin…' : 'Auto-filled from the pin'}
+              value={hospAddr}
+              onChangeText={setHospAddr}
+              variant="area"
+              multiline
+            />
+          </View>
+
+          {/* ── Notes (low-priority, optional) ───────────────────────── */}
+          <View>
+            <SectionLabel theme={theme}>Anything else? (optional)</SectionLabel>
+            <Input
+              placeholder="Patient name, ward, contact — anything that helps a donor reach you faster"
+              value={notes}
+              onChangeText={setNotes}
+              variant="area"
+              multiline
+            />
+          </View>
+
+          {/* ── Preview card (last verification before commit) ───────── */}
+          <View>
+            <SectionLabel theme={theme}>What donors will see</SectionLabel>
+            <View style={[styles.previewCard, { backgroundColor: theme.cardElevated, borderColor: theme.border }]}>
+              <View style={[styles.previewStripe, { backgroundColor: theme.primary }]} />
+              <View style={styles.previewBody}>
+                <View style={styles.previewTopRow}>
+                  <BloodGroupBadge bloodGroup={bloodGroup} size="md" variant="solid" />
+                  <View style={{ flex: 1 }}>
+                    <Text style={[styles.previewHospital, { color: theme.textPrimary }]} numberOfLines={1}>
+                      {hospital.trim() || 'Hospital'}
+                    </Text>
+                    <Text style={[styles.previewAddr, { color: theme.textMuted }]} numberOfLines={1}>
+                      {hospAddr || 'Address auto-fills'}
+                    </Text>
+                  </View>
+                </View>
+                <View style={styles.previewMeta}>
+                  <PreviewChip
+                    iconName={URGENCY_META[urgency].iconName}
+                    label={URGENCY_META[urgency].label}
+                    color={
+                      urgency === 'critical' ? theme.danger
+                      : urgency === 'urgent'  ? theme.warning
+                      :                          theme.success
+                    }
+                    theme={theme}
+                  />
+                  <PreviewChip
+                    iconName="people-outline"
+                    label={`${units} donor${units === 1 ? '' : 's'}`}
+                    color={theme.primary}
+                    theme={theme}
+                  />
+                  {donorCount > 0 && (
+                    <PreviewChip
+                      iconName="pulse"
+                      label={`${donorCount} ready`}
+                      color={theme.success}
+                      theme={theme}
+                    />
+                  )}
+                </View>
+              </View>
+            </View>
+          </View>
+
+          {/* ── In-form CTA (ACT) ──────────────────────────────────────
+              Lives at the natural end of the form (commitment device): the
+              user scrolls past every field, sees the preview, then commits.
+              Summary row above the button mirrors the urgency tier so the
+              decision is verified one last time before the tap. Breathes
+              when urgency is critical (loss-aversion via motion). */}
+          <View style={styles.ctaInline}>
+            <View style={styles.ctaSummary}>
+              <View style={[styles.ctaSummaryDot, { backgroundColor: ctaAccent }]} />
+              <Text style={[styles.ctaSummaryText, { color: theme.textPrimary }]} numberOfLines={1}>
+                <Text style={{ fontWeight: FontWeight.black, color: ctaAccent }}>
+                  {URGENCY_META[urgency].label}
+                </Text>
+                <Text style={{ color: theme.textMuted }}>{'  ·  '}</Text>
+                <Text>{bloodGroup}</Text>
+                <Text style={{ color: theme.textMuted }}>{'  ·  '}</Text>
+                <Text>{units} {units === 1 ? 'unit' : 'units'}</Text>
+              </Text>
+              {donorCount > 0 && (
+                <View style={[styles.ctaSummaryPill, { backgroundColor: theme.success + '1F', borderColor: theme.success + '55' }]}>
+                  <View style={[styles.ctaSummaryPillDot, { backgroundColor: theme.success }]} />
+                  <Text style={[styles.ctaSummaryPillText, { color: theme.success }]}>
+                    {donorCount} live
+                  </Text>
+                </View>
+              )}
+            </View>
+
+            <BreathingWrapper enabled={urgency === 'critical' && !loading}>
+              <Button
+                label={ctaLabel}
+                onPress={submit}
+                disabled={submitDisabled}
+                loading={loading}
+                fullWidth
+                size="xl"
+                variant="primary"
+                haptic={false}
+                icon={<Ionicons name="paper-plane" size={18} color={theme.textOnPrimary} />}
+                iconPosition="left"
+              />
+            </BreathingWrapper>
+
+            <Text style={[styles.ctaFooterNote, { color: theme.textMuted }]}>
+              By posting, you agree donor contact details are shared only
+              after a donor accepts.
+            </Text>
+          </View>
+        </ScrollView>
+      </Animated.View>
     </KeyboardAvoidingView>
   );
 }
 
-function Section({ label, children, theme }: { label: string; children: React.ReactNode; theme: any }) {
+function SectionLabel({ theme, children }: { theme: any; children: React.ReactNode }) {
   return (
-    <View style={styles.section}>
-      <Text style={[styles.sectionLabel, { color: theme.textMuted }]}>{label}</Text>
-      {children}
-    </View>
+    <Text style={{
+      fontSize: FontSize.xs,
+      fontWeight: FontWeight.black,
+      letterSpacing: LetterSpacing.widest,
+      textTransform: 'uppercase',
+      color: theme.textMuted,
+      marginLeft: Spacing[2],
+      marginBottom: Spacing[2],
+    }}>{children}</Text>
   );
 }
 
+function PreviewChip({
+  iconName, label, color, theme,
+}: { iconName: keyof typeof Ionicons.glyphMap; label: string; color: string; theme: any }) {
+  return (
+    <View style={[
+      previewChipStyles.chip,
+      { backgroundColor: color + '1F', borderColor: color + '55' },
+    ]}>
+      <Ionicons name={iconName} size={12} color={color} />
+      <Text style={[previewChipStyles.label, { color }]}>{label}</Text>
+    </View>
+  );
+}
+const previewChipStyles = StyleSheet.create({
+  chip: {
+    flexDirection: 'row', alignItems: 'center', gap: 4,
+    paddingHorizontal: Spacing[2], paddingVertical: 3,
+    borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
+  },
+  label: {
+    fontSize: FontSize['2xs'], fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.snug, textTransform: 'uppercase',
+  },
+});
+
 const styles = StyleSheet.create({
-  root:          { flex: 1 },
-  topBar:        { paddingHorizontal: Spacing[5], paddingBottom: Spacing[4], borderBottomWidth: StyleSheet.hairlineWidth },
-  pageTitle:     { fontSize: FontSize.xl, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.tight },
-  pageSubtitle:  { fontSize: FontSize.sm, marginTop: 2 },
-  scroll:        { padding: Spacing[5], gap: Spacing[6] },
-  section:       { gap: Spacing[3] },
-  sectionLabel:  { fontSize: FontSize.xs, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.widest, textTransform: 'uppercase' },
-  bloodGrid:     { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing[2] },
-  bloodBtn:      { borderRadius: Radius.sm, padding: Spacing[2] },
-  urgencyRow:    { flexDirection: 'row', gap: Spacing[2] },
-  urgencyBtn:    { flex: 1, alignItems: 'center', padding: Spacing[3], borderRadius: Radius.sm, gap: Spacing[1] },
-  urgencyIcon:   { fontSize: 20 },
-  urgencyLabel:  { fontSize: FontSize.xs, fontWeight: FontWeight.bold, textTransform: 'uppercase', letterSpacing: LetterSpacing.wide },
-  unitsRow:      { flexDirection: 'row', gap: Spacing[2] },
-  unitBtn:       { width: 52, height: 52, borderRadius: Radius.sm, alignItems: 'center', justifyContent: 'center' },
-  unitLabel:     { fontSize: FontSize.base, fontWeight: FontWeight.black },
-  locRow:        { flexDirection: 'row', alignItems: 'center', gap: Spacing[3], padding: Spacing[4], borderRadius: Radius.sm, borderWidth: StyleSheet.hairlineWidth },
-  locIcon:       { width: 44, height: 44, borderRadius: Radius.xs, alignItems: 'center', justifyContent: 'center' },
-  locTitle:      { fontSize: FontSize.sm, fontWeight: FontWeight.bold },
-  locSub:        { fontSize: FontSize.xs, marginTop: 2 },
-  ctaWrap:       { gap: Spacing[3] },
-  privacyNote:   { fontSize: FontSize.xs, textAlign: 'center' },
+  root: { flex: 1 },
+
+  // ── Map ────────────────────────────────────────────────────────────────
+  mapWrap: { position: 'relative', backgroundColor: '#1a1a1a' },
+  mapTop: {
+    position: 'absolute', left: Spacing[4], right: Spacing[4],
+    flexDirection: 'row', alignItems: 'center',
+  },
+  recentreBtn: {
+    width: 40, height: 40, borderRadius: Radius.pill,
+    alignItems: 'center', justifyContent: 'center',
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  donorBadge: {
+    position: 'absolute',
+    flexDirection: 'row', alignItems: 'center', gap: Spacing[2],
+    paddingHorizontal: Spacing[3], paddingVertical: Spacing[2],
+    borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
+    maxWidth: '60%',
+  },
+  liveDotWrap: {
+    width: 12, height: 12, alignItems: 'center', justifyContent: 'center',
+  },
+  liveDotOuter: { position: 'absolute', width: 12, height: 12, borderRadius: 6 },
+  liveDot: { width: 6, height: 6, borderRadius: 3 },
+  donorBadgeNumber: {
+    fontSize: FontSize.sm, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.snug,
+  },
+  donorBadgeSub: { fontSize: FontSize['2xs'], fontWeight: FontWeight.semibold, marginTop: 1 },
+
+  mapHint: {
+    position: 'absolute',
+    flexDirection: 'row', alignItems: 'center', gap: 4,
+    paddingHorizontal: Spacing[3], paddingVertical: Spacing[1],
+    borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
+  },
+  mapHintText: {
+    fontSize: FontSize['2xs'], fontWeight: FontWeight.semibold, letterSpacing: LetterSpacing.snug,
+  },
+  bigPin: {
+    width: 40, height: 40, borderRadius: 20,
+    alignItems: 'center', justifyContent: 'center',
+    borderWidth: 3, ...Elevation.sm,
+  },
+
+  // ── Sheet ──────────────────────────────────────────────────────────────
+  sheet: {
+    flex: 1,
+    borderTopLeftRadius:  Radius['2xl'],
+    borderTopRightRadius: Radius['2xl'],
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  sheetTop: { alignItems: 'center', paddingTop: Spacing[2], paddingBottom: Spacing[3] },
+  accentStrip: {
+    width: 36, height: 3, borderRadius: 2, marginBottom: Spacing[1],
+    opacity: 0.9,
+  },
+  handle: { width: 44, height: 4, borderRadius: 2 },
+
+  // ── Route summary bar ──────────────────────────────────────────────────
+  routeBar: {
+    flexDirection: 'row', gap: Spacing[3],
+    padding: Spacing[4],
+    borderRadius: Radius.xl,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  routeCol: { alignItems: 'center', paddingTop: 4 },
+  routeDot: { width: 10, height: 10, borderRadius: 5, borderWidth: 2 },
+  routeLine: { width: 2, flex: 1, marginVertical: 4 },
+  routeLabel: {
+    fontSize: FontSize['2xs'], fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest, textTransform: 'uppercase',
+  },
+  routeValue: {
+    fontSize: FontSize.sm, fontWeight: FontWeight.bold,
+    letterSpacing: LetterSpacing.snug, marginTop: 2,
+  },
+
+  urgencySub: {
+    fontSize: FontSize.xs, fontWeight: FontWeight.semibold,
+    letterSpacing: LetterSpacing.snug,
+    marginLeft: Spacing[2], marginTop: Spacing[2],
+    lineHeight: FontSize.xs * 1.5,
+  },
+
+  // ── Blood group grid ─────────────────────────────────────────────────
+  bloodGrid: {
+    flexDirection: 'row', flexWrap: 'wrap',
+    gap: Spacing[2],
+  },
+  bloodCell: {
+    width: '23%',
+    paddingVertical: Spacing[4],
+    alignItems: 'center', justifyContent: 'center',
+    borderRadius: Radius.xl, borderWidth: 1.5,
+  },
+  bloodCellLabel: {
+    fontSize: FontSize.lg, fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.tight,
+  },
+
+  // ── Units stepper ─────────────────────────────────────────────────────
+  unitsWrap: {
+    flexDirection: 'row', alignItems: 'center',
+    borderRadius: Radius.xl, borderWidth: 1.5,
+    height: 80, overflow: 'hidden',
+  },
+  unitsBtn: {
+    width: 60, height: '100%',
+    alignItems: 'center', justifyContent: 'center',
+  },
+  unitsCenter: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 2 },
+  unitsValue: {
+    fontSize: FontSize['2xl'], fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.tighter,
+  },
+  unitsDots: { flexDirection: 'row', alignItems: 'center', gap: 3, marginTop: 2, marginBottom: 1 },
+  unitsDot: { width: 5, height: 5, borderRadius: 2.5 },
+  unitsMore: { fontSize: FontSize['2xs'], fontWeight: FontWeight.semibold, marginLeft: 2 },
+  unitsLabel: {
+    fontSize: FontSize.xs, fontWeight: FontWeight.semibold,
+    letterSpacing: LetterSpacing.snug,
+  },
+
+  // ── Preview card ──────────────────────────────────────────────────────
+  previewCard: {
+    flexDirection: 'row',
+    borderRadius: Radius.xl,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+  },
+  previewStripe: { width: 4 },
+  previewBody: { flex: 1, padding: Spacing[4], gap: Spacing[3] },
+  previewTopRow: {
+    flexDirection: 'row', alignItems: 'center', gap: Spacing[3],
+  },
+  previewHospital: {
+    fontSize: FontSize.base, fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.snug,
+  },
+  previewAddr: { fontSize: FontSize.xs, marginTop: 2 },
+  previewMeta: { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing[2] },
+
+  // ── In-form CTA ────────────────────────────────────────────────────────
+  ctaInline: {
+    marginTop: Spacing[2],
+    gap: Spacing[3],
+  },
+  ctaFooterNote: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.medium,
+    letterSpacing: LetterSpacing.snug,
+    textAlign: 'center',
+    paddingHorizontal: Spacing[4],
+    lineHeight: FontSize.xs * 1.5,
+  },
+  ctaSummary: {
+    flexDirection: 'row', alignItems: 'center',
+    gap: Spacing[2],
+    paddingHorizontal: Spacing[1],
+  },
+  ctaSummaryDot: {
+    width: 8, height: 8, borderRadius: 4,
+  },
+  ctaSummaryText: {
+    flex: 1,
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.bold,
+    letterSpacing: LetterSpacing.snug,
+  },
+  ctaSummaryPill: {
+    flexDirection: 'row', alignItems: 'center',
+    gap: 5,
+    paddingHorizontal: Spacing[2], paddingVertical: 3,
+    borderRadius: Radius.pill,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  ctaSummaryPillDot: { width: 5, height: 5, borderRadius: 2.5 },
+  ctaSummaryPillText: {
+    fontSize: FontSize['2xs'],
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.snug,
+    textTransform: 'uppercase',
+  },
 });

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -33,7 +33,7 @@ SplashScreen.preventAutoHideAsync();
 // Any segment[0] in this set is considered a valid "inside the app" location.
 // Without this, opening a deep link like /request/abc on cold start bounces the
 // user to (tabs) — destroying the link target.
-const IN_APP_SEGMENTS = new Set(['(tabs)', 'request', 'donor', 'map', 'chat']);
+const IN_APP_SEGMENTS = new Set(['(tabs)', 'request', 'donor', 'map', 'chat', 'profile']);
 
 // ── Push-tap deep-link router ────────────────────────────────────────────────
 // Backend pushes carry `data.requestId` (and an optional `screen`). When the
@@ -179,6 +179,7 @@ function RootNavigator() {
         <Stack.Screen name="donor/[id]"   options={{ presentation: 'modal', animation: 'slide_from_bottom' }} />
         <Stack.Screen name="map/live"     options={{ headerShown: false, gestureEnabled: false }} />
         <Stack.Screen name="chat"         options={{ presentation: 'modal', animation: 'slide_from_bottom' }} />
+        <Stack.Screen name="profile/edit" options={{ presentation: 'modal', animation: 'slide_from_bottom' }} />
       </Stack>
     </>
   );

--- a/mobile/app/chat.tsx
+++ b/mobile/app/chat.tsx
@@ -24,10 +24,11 @@ import {
   KeyboardAvoidingView, Platform,
 } from 'react-native';
 import Skeleton from '@/components/Skeleton';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
 import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { useChatMessages, type ChatMessage } from '@/hooks/useChatMessages';
@@ -44,6 +45,7 @@ export default function ChatScreen() {
   const { theme }    = useTheme();
   const { user }     = useAuth();
   const router       = useRouter();
+  const insets       = useSafeAreaInsets();
   const listRef      = useRef<FlashListRef<ChatMessage>>(null);
 
   const {
@@ -69,6 +71,7 @@ export default function ChatScreen() {
     if (!trimmed || sending) return;
     setSending(true);
     setText('');
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
     try {
       await sendMessage(trimmed);
       // Auto-scroll regardless of current position when the user themselves sends.
@@ -179,9 +182,18 @@ export default function ChatScreen() {
 
   if (loading) return <LoadingScreen message="Loading messages…" />;
 
+  // KeyboardAvoidingView setup:
+  //   • SafeAreaView claims only the TOP edge — bottom edge is owned by the
+  //     KeyboardAvoidingView so it can fully push the composer above the
+  //     keyboard with no double-padding gap.
+  //   • iOS uses `padding` (smooth slide) with offset = 0 because there's no
+  //     translucent status bar to compensate for.
+  //   • Android uses `height` (KAV adjusts its own height); `padding` on
+  //     Android intermittently leaves a gap on devices with edge-to-edge
+  //     gesture areas. The bottom inset is added explicitly to the input bar
+  //     instead so the composer never touches the gesture indicator.
   return (
-    <SafeAreaView style={[styles.root, { backgroundColor: theme.background }]} edges={['top', 'bottom']}>
-
+    <SafeAreaView style={[styles.root, { backgroundColor: theme.background }]} edges={['top']}>
       {/* ── Header ───────────────────────────────────────────────────── */}
       <View style={[styles.header, { borderBottomColor: theme.border, backgroundColor: theme.surface }]}>
         <TouchableOpacity onPress={() => router.back()} style={styles.backBtn} activeOpacity={0.7}>
@@ -213,7 +225,7 @@ export default function ChatScreen() {
 
       <KeyboardAvoidingView
         style={{ flex: 1 }}
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         keyboardVerticalOffset={0}
       >
         {/* ── Messages list (FlashList v2) ───────────────────────────── */}
@@ -233,8 +245,19 @@ export default function ChatScreen() {
           getItemType={() => 'text'}
         />
 
-        {/* ── Input bar ──────────────────────────────────────────────── */}
-        <View style={[styles.inputBar, { backgroundColor: theme.surface, borderTopColor: theme.border }]}>
+        {/* ── Input bar — bottom inset baked into paddingBottom so the
+            composer never sits on the gesture indicator on Android, and so
+            the keyboard never hides it on either platform. */}
+        <View
+          style={[
+            styles.inputBar,
+            {
+              backgroundColor: theme.surface,
+              borderTopColor:  theme.border,
+              paddingBottom:   Math.max(insets.bottom, Spacing[3]),
+            },
+          ]}
+        >
           <View style={[styles.inputWrap, { backgroundColor: theme.inputBg, borderColor: theme.inputBorder }]}>
             <TextInput
               value={text}
@@ -297,8 +320,8 @@ const styles = StyleSheet.create({
   headerName:    { fontSize: FontSize.sm, fontWeight: FontWeight.black },
   headerSub:     { fontSize: FontSize.xs, marginTop: 1 },
   viewReqBtn: {
-    paddingHorizontal: Spacing[2], paddingVertical: Spacing[1],
-    borderRadius: Radius.xs, borderWidth: 1,
+    paddingHorizontal: Spacing[3], paddingVertical: Spacing[1],
+    borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
   },
   viewReqLabel: { fontSize: FontSize.xs, fontWeight: FontWeight.medium },
 

--- a/mobile/app/donor/[id].tsx
+++ b/mobile/app/donor/[id].tsx
@@ -9,8 +9,10 @@ import {
     TouchableOpacity, Alert, Linking, Animated,
 } from 'react-native';
 import { Image } from 'expo-image';
+import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
+import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/utils/supabase';
@@ -60,24 +62,33 @@ interface DonorResponse {
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-const URGENCY_COLOR: Record<string, string> = {
-    critical: '#E8002D',
-    urgent: '#F5A623',
-    standard: '#00A651',
+// Tone keys resolved through the theme inside the component (see toneColor()).
+type ToneKey = 'success' | 'warning' | 'danger' | 'muted';
+const URGENCY_TONE: Record<string, ToneKey> = {
+    critical: 'danger',
+    urgent:   'warning',
+    standard: 'success',
 };
 
-const RESPONSE_STATUS_CONFIG: Record<string, { label: string; color: string }> = {
-    pending: { label: 'Pending', color: '#F5A623' },
-    accepted: { label: 'Accepted', color: '#00A651' },
-    declined: { label: 'Declined', color: '#9B9B9B' },
-    completed: { label: 'Completed', color: '#00A651' },
+const RESPONSE_STATUS_CONFIG: Record<string, { label: string; tone: ToneKey }> = {
+    pending:   { label: 'Pending',   tone: 'warning' },
+    accepted:  { label: 'Accepted',  tone: 'success' },
+    declined:  { label: 'Declined',  tone: 'muted'   },
+    completed: { label: 'Completed', tone: 'success' },
 };
 
 // ─── Screen ──────────────────────────────────────────────────────────────────
 
 export default function DonorDetailScreen() {
-    const { id } = useLocalSearchParams<{ id: string }>();
+    // Accepts an optional `requestId` query param so the Message button can
+    // open the in-app chat scoped to the right thread when navigated from a
+    // specific request detail screen. When absent, we discover the most
+    // recent accepted/completed response between the viewer and this donor
+    // (or vice-versa) and scope the chat to that request.
+    const { id, requestId: passedRequestId } = useLocalSearchParams<{
+        id: string;
+        requestId?: string;
+    }>();
     const { theme, isDark } = useTheme();
     const { user, profile: myProfile } = useAuth();
     const router = useRouter();
@@ -87,6 +98,11 @@ export default function DonorDetailScreen() {
     const [donor, setDonor] = useState<DonorProfile | null>(null);
     const [responses, setResponses] = useState<DonorResponse[]>([]);
     const [loading, setLoading] = useState(true);
+    // Resolved request_id for the chat thread. Either the one passed via
+    // query param, or discovered from a recent mutual-commitment response.
+    const [chatRequestId, setChatRequestId] = useState<string | null>(
+        passedRequestId ?? null,
+    );
 
     // Subtle entrance animation for the avatar
     const fadeAnim = useRef(new Animated.Value(0)).current;
@@ -148,6 +164,55 @@ export default function DonorDetailScreen() {
         Promise.all([fetchDonor(), fetchResponses()]).finally(() => setLoading(false));
     }, [id]);
 
+    // Discover a chat thread when no requestId was passed via query param.
+    // Looks for any accepted/completed response between the viewer and the
+    // donor on either side (donor accepted my request, or I accepted theirs)
+    // and uses the most recent one. The mutual-commitment RLS policy makes
+    // this read safe for both parties.
+    useEffect(() => {
+        if (passedRequestId || !user?.id || !id || user.id === id) return;
+        let cancelled = false;
+        (async () => {
+            try {
+                // Path A: this profile is a donor who accepted MY (viewer = recipient's) request
+                const { data: aData } = await supabase
+                    .from('request_responses')
+                    .select('request_id, created_at, blood_requests!inner(recipient_id)')
+                    .eq('donor_id', id)
+                    .in('status', ['accepted', 'completed'])
+                    .eq('blood_requests.recipient_id', user.id)
+                    .order('created_at', { ascending: false })
+                    .limit(1)
+                    .maybeSingle();
+
+                if (cancelled) return;
+                if ((aData as any)?.request_id) {
+                    setChatRequestId((aData as any).request_id);
+                    return;
+                }
+
+                // Path B: I (viewer = donor) accepted THIS profile's (recipient's) request
+                const { data: bData } = await supabase
+                    .from('request_responses')
+                    .select('request_id, created_at, blood_requests!inner(recipient_id)')
+                    .eq('donor_id', user.id)
+                    .in('status', ['accepted', 'completed'])
+                    .eq('blood_requests.recipient_id', id)
+                    .order('created_at', { ascending: false })
+                    .limit(1)
+                    .maybeSingle();
+
+                if (cancelled) return;
+                if ((bData as any)?.request_id) {
+                    setChatRequestId((bData as any).request_id);
+                }
+            } catch (e: any) {
+                if (!cancelled) console.warn('[DonorDetail chat-thread]', e?.message);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [passedRequestId, user?.id, id]);
+
     // ── Derived values ───────────────────────────────────────────────────────
     const isOwnProfile = user?.id === id;
 
@@ -156,7 +221,7 @@ export default function DonorDetailScreen() {
         : { canDonate: false, daysLeft: 0 };
 
     const available = donor?.is_available_to_donate && canDonate;
-    const statusColor = available ? '#00A651' : '#F5A623';
+    const statusColor = available ? theme.success : theme.warning;
 
     const distance = location && donor?.latitude && donor?.longitude
         ? haversineDistance(location.latitude, location.longitude, donor.latitude, donor.longitude)
@@ -180,16 +245,38 @@ export default function DonorDetailScreen() {
         if (!donor) return;
         const target = donor.phone ?? donor.email;
         if (!target) return Alert.alert('No contact info', 'This donor has not shared contact details.');
+        Haptics.selectionAsync().catch(() => {});
         Linking.openURL(donor.phone ? `tel:${donor.phone}` : `mailto:${donor.email}`);
     }, [donor]);
 
+    // In-app chat — NEVER email. Chat threads are scoped to a request_id so
+    // both parties open the same conversation that lives behind the existing
+    // mutual-commitment RLS. If no chat thread is discoverable, we tell the
+    // user up-front instead of silently opening a broken composer.
     const handleMessage = useCallback(() => {
-        if (!donor?.email) return;
-        Linking.openURL(`mailto:${donor.email}`);
-    }, [donor]);
+        if (!donor || !user?.id) return;
+        if (user.id === donor.id) return; // can't message yourself
+        if (!chatRequestId) {
+            Alert.alert(
+                'No active thread yet',
+                "Chat opens once you've accepted each other through a request. Accept or post one to start a conversation.",
+            );
+            return;
+        }
+        Haptics.selectionAsync().catch(() => {});
+        router.push({
+            pathname: '/chat',
+            params: {
+                requestId:    String(chatRequestId),
+                receiverId:   donor.id,
+                receiverName: encodeURIComponent(donor.full_name ?? 'Donor'),
+            },
+        } as any);
+    }, [donor, user?.id, chatRequestId, router]);
 
     const handleOpenMap = useCallback(() => {
         if (!donor?.latitude || !donor?.longitude) return;
+        Haptics.selectionAsync().catch(() => {});
         Linking.openURL(
             `https://www.google.com/maps/dir/?api=1&destination=${donor.latitude},${donor.longitude}&travelmode=driving`
         );
@@ -205,7 +292,7 @@ export default function DonorDetailScreen() {
 
             {/* ── Top bar ── */}
             <View style={[styles.topBar, {
-                paddingTop: insets.top + Spacing[2],
+                paddingTop: Spacing[2],
                 backgroundColor: theme.surface,
                 borderBottomColor: theme.border,
             }]}>
@@ -254,8 +341,9 @@ export default function DonorDetailScreen() {
                                 {donor.full_name}
                             </Text>
                             {donor.is_verified && (
-                                <View style={[styles.verifiedBadge, { backgroundColor: '#00A65118' }]}>
-                                    <Text style={[styles.verifiedText, { color: '#00A651' }]}>✓ Verified</Text>
+                                <View style={[styles.verifiedBadge, { backgroundColor: theme.successSoft }]}>
+                                    <Ionicons name="checkmark-circle" size={12} color={theme.success} />
+                                    <Text style={[styles.verifiedText, { color: theme.success }]}>Verified</Text>
                                 </View>
                             )}
                         </View>
@@ -270,7 +358,7 @@ export default function DonorDetailScreen() {
 
                         {donor.address && (
                             <Text style={[styles.addressText, { color: theme.textMuted }]} numberOfLines={1}>
-                                📍 {donor.address}
+                                {donor.address}
                             </Text>
                         )}
                     </View>
@@ -315,7 +403,11 @@ export default function DonorDetailScreen() {
                             borderColor: canDonateToMe ? '#00A65130' : '#E8002D25',
                         },
                     ]}>
-                        <Text style={styles.compatIcon}>{canDonateToMe ? '✅' : '⚠️'}</Text>
+                        <Ionicons
+                            name={canDonateToMe ? 'checkmark-circle' : 'warning'}
+                            size={22}
+                            color={canDonateToMe ? theme.success : theme.warning}
+                        />
                         <Text style={[styles.compatText, { color: theme.textSecondary }]}>
                             {canDonateToMe
                                 ? `${donor.blood_group} is compatible with your blood group (${myBloodGroup}). This donor can donate to you.`
@@ -364,14 +456,21 @@ export default function DonorDetailScreen() {
                 {/* ── Donation history (accepted/completed responses) ── */}
                 {responses.length > 0 && (
                     <SectionCard
-                        title={`🩸 DONATION HISTORY  ·  ${responses.length} record${responses.length !== 1 ? 's' : ''}`}
+                        title={`Donation history  ·  ${responses.length} record${responses.length !== 1 ? 's' : ''}`}
                         theme={theme}
                     >
                         {responses.map(resp => {
                             const req = resp.blood_request;
                             if (!req) return null;
-                            const statusCfg = RESPONSE_STATUS_CONFIG[resp.status] ?? { label: resp.status, color: theme.textMuted };
-                            const urgencyColor = URGENCY_COLOR[req.urgency] ?? '#E8002D';
+                            const statusCfg = RESPONSE_STATUS_CONFIG[resp.status] ?? { label: resp.status, tone: 'muted' as const };
+                            const urgencyTone = URGENCY_TONE[req.urgency] ?? 'danger';
+                            const toneColor = (t: ToneKey) =>
+                                t === 'success' ? theme.success
+                                : t === 'warning' ? theme.warning
+                                : t === 'danger'  ? theme.danger
+                                :                   theme.textMuted;
+                            const statusColor  = toneColor(statusCfg.tone);
+                            const urgencyColor = toneColor(urgencyTone);
                             return (
                                 <TouchableOpacity
                                     key={resp.id}
@@ -379,7 +478,7 @@ export default function DonorDetailScreen() {
                                     activeOpacity={0.75}
                                 >
                                     <View style={[styles.historyRow, { backgroundColor: theme.cardElevated, borderColor: theme.border }]}>
-                                        <BloodGroupBadge bloodGroup={req.blood_group} size="sm" inverted />
+                                        <BloodGroupBadge bloodGroup={req.blood_group} size="sm" variant="solid" />
                                         <View style={styles.historyMeta}>
                                             <Text style={[styles.historyHospital, { color: theme.textPrimary }]} numberOfLines={1}>
                                                 {req.hospital_name}
@@ -393,8 +492,8 @@ export default function DonorDetailScreen() {
                                         </View>
                                         <View style={styles.historyRight}>
                                             <View style={[styles.urgencyPip, { backgroundColor: urgencyColor }]} />
-                                            <View style={[styles.statusPill, { backgroundColor: `${statusCfg.color}18`, borderColor: `${statusCfg.color}40` }]}>
-                                                <Text style={[styles.statusPillText, { color: statusCfg.color }]}>
+                                            <View style={[styles.statusPill, { backgroundColor: statusColor + '22', borderColor: statusColor }]}>
+                                                <Text style={[styles.statusPillText, { color: statusColor }]}>
                                                     {statusCfg.label}
                                                 </Text>
                                             </View>
@@ -417,7 +516,8 @@ export default function DonorDetailScreen() {
                 {!isOwnProfile && (
                     <View style={styles.actionWrap}>
                         <Button
-                            label="📞  Call Donor"
+                            label="Call donor"
+                            icon={<Ionicons name="call" size={16} color="#fff" />}
                             variant="primary"
                             size="lg"
                             onPress={handleCall}
@@ -478,7 +578,7 @@ const styles = StyleSheet.create({
 
     // Hero card
     heroCard: {
-        borderRadius: Radius.md, borderWidth: StyleSheet.hairlineWidth,
+        borderRadius: Radius.xl, borderWidth: StyleSheet.hairlineWidth,
         overflow: 'hidden', padding: Spacing[5], gap: Spacing[4],
         alignItems: 'center',
     },
@@ -495,7 +595,7 @@ const styles = StyleSheet.create({
     heroMeta: { alignItems: 'center', gap: Spacing[1] },
     nameRow: { flexDirection: 'row', alignItems: 'center', gap: Spacing[2], flexWrap: 'wrap', justifyContent: 'center' },
     heroName: { fontSize: FontSize.lg, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.tight },
-    verifiedBadge: { paddingHorizontal: Spacing[2], paddingVertical: 2, borderRadius: Radius.xs },
+    verifiedBadge: { paddingHorizontal: Spacing[2], paddingVertical: 2, borderRadius: Radius.pill },
     verifiedText: { fontSize: FontSize['2xs'], fontWeight: FontWeight.black, letterSpacing: LetterSpacing.wide },
     availabilityText: { fontSize: FontSize.sm, fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.snug },
     addressText: { fontSize: FontSize.xs },
@@ -515,35 +615,35 @@ const styles = StyleSheet.create({
     // Compatibility banner
     compatBanner: {
         flexDirection: 'row', alignItems: 'flex-start', gap: Spacing[3],
-        padding: Spacing[3], borderRadius: Radius.sm, borderWidth: 1,
+        padding: Spacing[3], borderRadius: Radius.xl, borderWidth: 1,
     },
     compatIcon: { fontSize: 18 },
     compatText: { flex: 1, fontSize: FontSize.sm, lineHeight: 20 },
 
     // ETA card
-    etaCard: { borderRadius: Radius.md, borderWidth: StyleSheet.hairlineWidth, overflow: 'hidden' },
+    etaCard: { borderRadius: Radius.xl, borderWidth: StyleSheet.hairlineWidth, overflow: 'hidden' },
     etaInner: { flexDirection: 'row', alignItems: 'center', gap: Spacing[3], padding: Spacing[4] },
     etaStat: { flex: 1, alignItems: 'center', gap: 2 },
     etaValue: { fontSize: FontSize.base, fontWeight: FontWeight.black },
     etaLabel: { fontSize: FontSize['2xs'], fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.widest, textTransform: 'uppercase' },
     etaDivider: { width: StyleSheet.hairlineWidth, height: 28 },
-    dirBtn: { paddingHorizontal: Spacing[3], paddingVertical: Spacing[2], borderRadius: Radius.xs },
+    dirBtn: { paddingHorizontal: Spacing[3], paddingVertical: Spacing[2], borderRadius: Radius.pill },
     dirBtnText: { color: '#fff', fontSize: FontSize.xs, fontWeight: FontWeight.black },
 
     // Section card
-    sectionCard: { borderRadius: Radius.md, borderWidth: StyleSheet.hairlineWidth, overflow: 'hidden', padding: Spacing[4] },
+    sectionCard: { borderRadius: Radius.xl, borderWidth: StyleSheet.hairlineWidth, overflow: 'hidden', padding: Spacing[4] },
     sectionLabel: { fontSize: FontSize['2xs'], fontWeight: FontWeight.black, letterSpacing: LetterSpacing.widest, textTransform: 'uppercase', marginBottom: Spacing[3] },
     sectionBody: { gap: Spacing[2] },
 
     // Medical tags
     tags: { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing[2] },
-    tag: { paddingHorizontal: Spacing[2], paddingVertical: Spacing[1], borderRadius: Radius.xs },
+    tag: { paddingHorizontal: Spacing[2], paddingVertical: Spacing[1], borderRadius: Radius.pill },
     tagText: { fontSize: FontSize.xs },
 
     // History rows
     historyRow: {
         flexDirection: 'row', alignItems: 'center', gap: Spacing[3],
-        padding: Spacing[3], borderRadius: Radius.sm, borderWidth: StyleSheet.hairlineWidth,
+        padding: Spacing[3], borderRadius: Radius.xl, borderWidth: StyleSheet.hairlineWidth,
     },
     historyMeta: { flex: 1, gap: 2 },
     historyHospital: { fontSize: FontSize.sm, fontWeight: FontWeight.black },
@@ -558,7 +658,7 @@ const styles = StyleSheet.create({
     statusPillText: { fontSize: FontSize['2xs'], fontWeight: FontWeight.black, textTransform: 'uppercase', letterSpacing: LetterSpacing.wide },
 
     // Member since
-    memberRow: { borderWidth: StyleSheet.hairlineWidth, borderRadius: Radius.xs, padding: Spacing[3], alignItems: 'center' },
+    memberRow: { borderWidth: StyleSheet.hairlineWidth, borderRadius: Radius.xl, padding: Spacing[3], alignItems: 'center' },
     memberText: { fontSize: FontSize.xs },
 
     // Actions

--- a/mobile/app/map/live.tsx
+++ b/mobile/app/map/live.tsx
@@ -11,8 +11,10 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import MapView, { Marker, Polyline, PROVIDER_DEFAULT } from 'react-native-maps';
+import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import * as Location from 'expo-location';
+import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/utils/supabase';
@@ -81,18 +83,37 @@ export default function LiveMapScreen() {
     }
   }, [requestId]);
 
-  // Load accepted donors' locations (for recipient view)
+  // Load accepted donors' live locations from request_responses.
+  // Source of truth = request_responses.donor_lat/donor_lon, pushed via
+  // /donations/heartbeat. Falls back to profile-level lat/lon only if the
+  // donor hasn't started heartbeating yet (rare).
   const loadDonors = useCallback(async () => {
     if (!requestId || role !== 'recipient') return;
     const { data } = await supabase
       .from('request_responses')
-      .select('donor_id, donor:profiles!donor_id(id, full_name, blood_group, latitude, longitude)')
+      .select(`
+        donor_id, donor_lat, donor_lon, donor_location_updated_at,
+        donor:profiles!donor_id ( id, full_name, blood_group )
+      `)
       .eq('request_id', requestId)
       .eq('status', 'accepted');
 
-    const donorData = (data ?? [])
-      .map((r: any) => r.donor)
-      .filter((d: any) => d?.latitude && d?.longitude);
+    const donorData: DonorLocation[] = (data ?? [])
+      .map((r: any) => {
+        const d = r.donor;
+        if (!d) return null;
+        const lat = r.donor_lat;
+        const lon = r.donor_lon;
+        if (lat == null || lon == null) return null;
+        return {
+          id:          d.id,
+          latitude:    lat,
+          longitude:   lon,
+          full_name:   d.full_name,
+          blood_group: d.blood_group,
+        };
+      })
+      .filter(Boolean) as DonorLocation[];
     setDonors(donorData);
   }, [requestId, role]);
 
@@ -101,10 +122,14 @@ export default function LiveMapScreen() {
     loadRequest();
     loadDonors();
 
-    // Real-time donor location updates
+    // Realtime: subscribe to UPDATEs on request_responses for this request.
+    // RLS allows the recipient to see donor responses on their own requests.
     const sub = supabase
-      .channel('live_locations')
-      .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'profiles' }, loadDonors)
+      .channel(`live_${requestId}`)
+      .on('postgres_changes', {
+        event: 'UPDATE', schema: 'public', table: 'request_responses',
+        filter: `request_id=eq.${requestId}`,
+      }, loadDonors)
       .subscribe();
 
     return () => {
@@ -123,9 +148,20 @@ export default function LiveMapScreen() {
 
   const openGoogleMaps = useCallback(() => {
     if (!requestLocation) return;
+    Haptics.selectionAsync().catch(() => {});
     const url = `https://www.google.com/maps/dir/?api=1&destination=${requestLocation.latitude},${requestLocation.longitude}&travelmode=driving`;
     Linking.openURL(url);
   }, [requestLocation]);
+
+  const closeMap = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    router.back();
+  }, [router]);
+
+  const onFit = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    fitToMarkers();
+  }, [fitToMarkers]);
 
   const distance = myLocation && requestLocation
     ? haversineDistance(myLocation.latitude, myLocation.longitude, requestLocation.latitude, requestLocation.longitude)
@@ -137,18 +173,21 @@ export default function LiveMapScreen() {
     <View style={[styles.root, { backgroundColor: theme.background }]}>
       {/* Top overlay */}
       <View style={[styles.topOverlay, { paddingTop: insets.top + Spacing[2] }]}>
-        <View style={[styles.topCard, { backgroundColor: theme.glass }]}>
-          <TouchableOpacity onPress={() => router.back()} style={styles.closeBtn} activeOpacity={0.8}>
-            <Text style={{ color: theme.accent, fontSize: 18 }}>✕</Text>
+        <View style={[styles.topCard, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+          <TouchableOpacity onPress={closeMap} style={styles.closeBtn} activeOpacity={0.8} accessibilityLabel="Close live map">
+            <Ionicons name="close" size={20} color={theme.textPrimary} />
           </TouchableOpacity>
           <View style={{ flex: 1 }}>
-            <Text style={[styles.liveLabel, { color: theme.primary }]}>● LIVE TRACKING</Text>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+              <View style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: theme.primary }} />
+              <Text style={[styles.liveLabel, { color: theme.primary }]}>LIVE TRACKING</Text>
+            </View>
             <Text style={[styles.hospitalText, { color: theme.textPrimary }]} numberOfLines={1}>
               {requestLocation?.hospital ?? 'Loading…'}
             </Text>
           </View>
-          <TouchableOpacity onPress={fitToMarkers} style={[styles.fitBtn, { backgroundColor: theme.muted, borderColor: theme.border }]}>
-            <Text style={{ fontSize: 16 }}>⊕</Text>
+          <TouchableOpacity onPress={onFit} style={[styles.fitBtn, { backgroundColor: theme.cardElevated, borderColor: theme.border }]} accessibilityLabel="Fit map to markers">
+            <Ionicons name="scan" size={18} color={theme.textPrimary} />
           </TouchableOpacity>
         </View>
       </View>
@@ -176,7 +215,7 @@ export default function LiveMapScreen() {
             description="Destination"
           >
             <View style={[styles.hospitalMarker, { backgroundColor: theme.primary }]}>
-              <Text style={styles.markerEmoji}>🏥</Text>
+              <Ionicons name="medical" size={18} color={theme.textOnPrimary} />
             </View>
           </Marker>
         )}
@@ -189,8 +228,8 @@ export default function LiveMapScreen() {
             title={donor.full_name}
             description={`${donor.blood_group} · Moving to hospital`}
           >
-            <View style={[styles.donorMarker, { backgroundColor: theme.accent }]}>
-              <Text style={styles.markerEmoji}>🩸</Text>
+            <View style={[styles.donorMarker, { backgroundColor: theme.primary }]}>
+              <Ionicons name="water" size={16} color={theme.textOnPrimary} />
             </View>
           </Marker>
         ))}
@@ -199,7 +238,7 @@ export default function LiveMapScreen() {
         {role === 'donor' && myLocation && requestLocation && (
           <Polyline
             coordinates={[myLocation, requestLocation]}
-            strokeColor={theme.accent}
+            strokeColor={theme.primary}
             strokeWidth={2.5}
             lineDashPattern={[6, 4]}
           />
@@ -218,7 +257,7 @@ export default function LiveMapScreen() {
           </View>
           <View style={[styles.statDivider, { backgroundColor: theme.border }]} />
           <View style={styles.statItem}>
-            <Text style={[styles.statValue, { color: theme.accent }]}>
+            <Text style={[styles.statValue, { color: theme.primary }]}>
               {distance !== null ? `${estimateDriveMinutes(distance)} min` : '—'}
             </Text>
             <Text style={[styles.statLabel, { color: theme.textMuted }]}>Est. Drive</Text>
@@ -236,7 +275,7 @@ export default function LiveMapScreen() {
         {role === 'recipient' && donors.length > 0 && (
           <View style={[styles.donorsRow, { borderTopColor: theme.border }]}>
             <Text style={[styles.donorsLabel, { color: theme.textSecondary }]}>
-              🩸 {donors.length} donor{donors.length !== 1 ? 's' : ''} en route
+              {donors.length} donor{donors.length !== 1 ? 's' : ''} en route
             </Text>
           </View>
         )}
@@ -244,7 +283,8 @@ export default function LiveMapScreen() {
         {/* CTA */}
         {role === 'donor' && (
           <Button
-            label="🗺️ Open in Google Maps"
+            label="Open in Google Maps"
+            icon={<Ionicons name="navigate" size={16} color={theme.textOnPrimary ?? '#fff'} />}
             variant="primary"
             size="lg"
             onPress={openGoogleMaps}

--- a/mobile/app/onboarding.tsx
+++ b/mobile/app/onboarding.tsx
@@ -1,4 +1,15 @@
 // app/onboarding.tsx
+// ──────────────────────────────────────────────────────────────────────────────
+// Request-screen design language for onboarding:
+//   • Hero zone with progress bar + step count (replaces Uber's map).
+//   • Sheet ascends -Spacing[5] over the hero with brand accent strip + handle
+//     + spring entrance.
+//   • Section labels (uppercase, black weight, widest letter spacing).
+//   • Inline CTA at the very end of each step's content — summary row + pill
+//     button + footer micro-copy. The final confirm step's CTA breathes (loss-
+//     aversion / commitment moment).
+//   • Haptics on every Pressable. Reanimated worklets only.
+//
 // Lever: progressive disclosure + commitment escalation. Role choice is the
 // first ask — every screen after it is conditional, so users only ever see
 // the next decision they have to make, never a wall of fields.
@@ -6,21 +17,19 @@
 // Server-enforced rules mirrored client-side (with kinder copy):
 //   • Donor / Both => date_of_birth REQUIRED and age >= 18
 //   • Recipient    => DOB and medical history are optional / skipped
-//
-// Copy lens: each step has a question header (most-aware framing) and a single
-// affirmative CTA. The role step uses BAB (Before/After/Bridge) — paint who
-// they want to be (a donor, a recipient, both) before asking for data.
+// ──────────────────────────────────────────────────────────────────────────────
 
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   KeyboardAvoidingView, Platform, Pressable, ScrollView, StyleSheet, Text, View,
-  useWindowDimensions,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
 import Animated, {
-  FadeIn, FadeOut, SlideInRight, SlideOutLeft,
+  useAnimatedStyle, useSharedValue, withSpring, withTiming, withRepeat, Easing,
+  SlideInRight, SlideOutLeft,
 } from 'react-native-reanimated';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useAuth, computeAge, type UserRole } from '@/contexts/AuthContext';
@@ -30,6 +39,7 @@ import Button from '@/components/Button';
 import Input from '@/components/Input';
 import BrandMark from '@/components/BrandMark';
 import SelectSheet from '@/components/SelectSheet';
+import ToggleSwitch from '@/components/ToggleSwitch';
 import {
   BLOOD_GROUPS, GENDER_OPTIONS, MEDICAL_CONDITIONS, type BloodGroup,
 } from '@/constants/BloodData';
@@ -73,12 +83,66 @@ const INITIAL_FORM: FormState = {
   phone: '', whatsapp: false,
 };
 
+// Step label shown above each step's title — mirrors the Request screen's
+// SectionLabel + tier label pattern.
+const STEP_HEADLINE: Record<StepKey, string> = {
+  role:     'Step 1 · How will you use BludStack?',
+  identity: 'Identity · How donors and recipients see you',
+  dob:      'Age · Eligibility check',
+  blood:    'Compatibility · Blood group',
+  medical:  'Disclosure · Health context (optional)',
+  contact:  'Reach · Phone (optional)',
+  confirm:  'Final · Last look',
+};
+
+// CTA copy mirrors step. The confirm step's CTA breathes for commitment.
+const STEP_CTA: Record<StepKey, string> = {
+  role: 'Continue',
+  identity: 'Next · Date of birth',
+  dob: 'Next · Blood group',
+  blood: 'Next · Continue',
+  medical: 'Next · Phone',
+  contact: 'Next · Review',
+  confirm: 'Save and continue',
+};
+
+// ── Sheet entrance + breathing utilities (same physics as Request screen) ──
+function useSheetEntrance() {
+  const ty = useSharedValue(60);
+  const op = useSharedValue(0);
+  useEffect(() => {
+    ty.value = withSpring(0, { damping: 16, stiffness: 180, mass: 0.6 });
+    op.value = withTiming(1, { duration: 280, easing: Easing.out(Easing.quad) });
+  }, [ty, op]);
+  return useAnimatedStyle(() => ({
+    transform: [{ translateY: ty.value }],
+    opacity: op.value,
+  }));
+}
+
+const BreathingWrapper = React.memo(function BreathingWrapper({
+  enabled, children,
+}: { enabled: boolean; children: React.ReactNode }) {
+  const s = useSharedValue(1);
+  useEffect(() => {
+    if (enabled) {
+      s.value = withRepeat(
+        withTiming(1.02, { duration: 1500, easing: Easing.inOut(Easing.quad) }),
+        -1, true,
+      );
+    } else {
+      s.value = withTiming(1, { duration: 200 });
+    }
+  }, [enabled, s]);
+  const style = useAnimatedStyle(() => ({ transform: [{ scale: s.value }] }));
+  return <Animated.View style={style}>{children}</Animated.View>;
+});
+
 export default function OnboardingScreen() {
   const { theme }     = useTheme();
   const { user, refreshProfile } = useAuth();
   const toast         = useToast();
   const insets        = useSafeAreaInsets();
-  const { width }     = useWindowDimensions();
 
   const [form, setForm]       = useState<FormState>(INITIAL_FORM);
   const [stepIdx, setStepIdx] = useState(0);
@@ -93,7 +157,7 @@ export default function OnboardingScreen() {
     return ['role', 'identity', 'dob', 'blood', 'medical', 'contact', 'confirm'];
   }, [form.role]);
 
-  const stepKey   = steps[stepIdx] ?? 'role';
+  const stepKey    = steps[stepIdx] ?? 'role';
   const totalSteps = steps.length;
   const progress   = Math.round(((stepIdx + 1) / totalSteps) * 100);
 
@@ -128,36 +192,20 @@ export default function OnboardingScreen() {
     if (Platform.OS !== 'ios') update('dobShownPicker', false);
   };
 
-  // ── Validation per step ──────────────────────────────────────────────────
   const validate = useCallback((): boolean => {
     switch (stepKey) {
       case 'role':
-        if (!form.role) {
-          setError('role', 'Pick how you want to use BludStack');
-          return false;
-        }
+        if (!form.role) { setError('role', 'Pick how you want to use BludStack'); return false; }
         break;
       case 'identity':
-        if (form.fullName.trim().length < 2) {
-          setError('identity', 'Tell us the name you go by');
-          return false;
-        }
-        if (!form.gender) {
-          setError('identity', 'Select a gender to continue');
-          return false;
-        }
+        if (form.fullName.trim().length < 2) { setError('identity', 'Tell us the name you go by'); return false; }
+        if (!form.gender)                    { setError('identity', 'Select a gender to continue'); return false; }
         break;
       case 'dob': {
         const iso = dobISO();
-        if (!iso) {
-          setError('dob', 'Enter a valid date of birth');
-          return false;
-        }
+        if (!iso) { setError('dob', 'Enter a valid date of birth'); return false; }
         const age = computeAge(iso);
-        if (age === null || age < 1 || age > 120) {
-          setError('dob', 'That date doesn\'t look right');
-          return false;
-        }
+        if (age === null || age < 1 || age > 120) { setError('dob', "That date doesn't look right"); return false; }
         if ((form.role === 'donor' || form.role === 'both') && age < MIN_DONOR_AGE) {
           setError('dob', `Donors must be ${MIN_DONOR_AGE} or older — switch to "Receive only" if you'd like to keep going`);
           return false;
@@ -165,15 +213,11 @@ export default function OnboardingScreen() {
         break;
       }
       case 'blood':
-        if (!form.bloodGroup) {
-          setError('blood', 'Select your blood group');
-          return false;
-        }
+        if (!form.bloodGroup) { setError('blood', 'Select your blood group'); return false; }
         break;
       case 'contact':
         if (form.phone.trim() && form.phone.replace(/\D/g, '').length < 7) {
-          setError('contact', 'Phone number looks too short');
-          return false;
+          setError('contact', 'Phone number looks too short'); return false;
         }
         break;
     }
@@ -181,10 +225,10 @@ export default function OnboardingScreen() {
     return true;
   }, [stepKey, form, dobISO, setError]);
 
-  // ── Submit ───────────────────────────────────────────────────────────────
   const submit = useCallback(async () => {
     if (!user?.id || !form.role || !form.bloodGroup) return;
     setLoading(true);
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
     try {
       const { downgraded } = await apiRegister({
         full_name:              form.fullName.trim(),
@@ -218,138 +262,220 @@ export default function OnboardingScreen() {
     }
   }, [user, form, dobISO, refreshProfile, toast]);
 
-  // ── Step navigation ──────────────────────────────────────────────────────
   const next = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
     if (!validate()) return;
     if (stepIdx < totalSteps - 1) setStepIdx(stepIdx + 1);
     else                          submit();
   }, [validate, stepIdx, totalSteps, submit]);
 
   const back = useCallback(() => {
-    if (stepIdx > 0) setStepIdx(stepIdx - 1);
+    if (stepIdx > 0) {
+      Haptics.selectionAsync().catch(() => {});
+      setStepIdx(stepIdx - 1);
+    }
   }, [stepIdx]);
 
-  const ctaLabel =
-    stepIdx === totalSteps - 1 ? 'Save and continue'
-    : stepKey === 'role'        ? 'Continue'
-    : 'Next';
+  const sheetEntrance = useSheetEntrance();
+  const isFinal = stepKey === 'confirm';
+
+  // Short summary line for the CTA summary row — mirrors Request screen.
+  const ctaSummaryLine = useMemo(() => {
+    const role = form.role || 'role';
+    const blood = form.bloodGroup || '—';
+    return `${role}  ·  ${blood}  ·  ${form.fullName.trim() || 'no name'}`;
+  }, [form.role, form.bloodGroup, form.fullName]);
 
   return (
     <KeyboardAvoidingView
       style={[styles.root, { backgroundColor: theme.background }]}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
-      {/* ── Header / progress ────────────────────────────────────────────── */}
-      <View style={[styles.header, { paddingTop: insets.top + Spacing[3] }]}>
+      {/* ─────────────────────── HERO (DECIDE) ───────────────────────────── */}
+      <View style={[styles.hero, { paddingTop: insets.top + Spacing[3], backgroundColor: theme.background }]}>
         <View style={styles.headerRow}>
           {stepIdx > 0 ? (
-            <Pressable onPress={back} hitSlop={8} style={styles.backBtn}>
+            <Pressable onPress={back} hitSlop={10} style={styles.backBtn}>
               <Ionicons name="chevron-back" size={22} color={theme.textPrimary} />
             </Pressable>
           ) : (
-            <BrandMark size={22} />
+            <View style={{ width: 40, alignItems: 'flex-start' }}>
+              <BrandMark size={24} />
+            </View>
           )}
           <Text style={[styles.stepCount, { color: theme.textMuted }]}>
             Step {stepIdx + 1} of {totalSteps}
           </Text>
           <View style={{ width: 40 }} />
         </View>
+
         <View style={[styles.progressTrack, { backgroundColor: theme.border }]}>
-          <View
-            style={[
-              styles.progressFill,
-              { width: `${progress}%`, backgroundColor: theme.primary },
-            ]}
-          />
+          <View style={[styles.progressFill, { width: `${progress}%`, backgroundColor: theme.primary }]} />
+        </View>
+
+        {/* Status pill, parity with Request screen's overlay pills */}
+        <View style={[styles.heroPill, { backgroundColor: theme.surface, borderColor: theme.border }, Elevation.sm]}>
+          <View style={[styles.heroPillDot, { backgroundColor: isFinal ? theme.success : theme.primary }]} />
+          <Text style={[styles.heroPillText, { color: theme.textMuted }]} numberOfLines={1}>
+            {isFinal ? 'Ready to save' : 'Onboarding in progress'}
+          </Text>
         </View>
       </View>
 
-      <ScrollView
-        contentContainerStyle={[styles.scroll, { paddingBottom: insets.bottom + Spacing[8] }]}
-        keyboardShouldPersistTaps="handled"
-        showsVerticalScrollIndicator={false}
+      {/* ─────────────────────── SHEET (VERIFY) ──────────────────────────── */}
+      <Animated.View
+        style={[
+          styles.sheet,
+          {
+            backgroundColor: theme.surface,
+            borderTopColor: theme.border,
+            marginTop: -Spacing[5],
+          },
+          Elevation.lg,
+          sheetEntrance,
+        ]}
       >
-        <Animated.View
-          key={stepKey}
-          entering={SlideInRight.duration(Motion.duration.base)}
-          exiting={SlideOutLeft.duration(Motion.duration.fast)}
-          style={styles.stepWrap}
-        >
-          {stepKey === 'role'     && (
-            <RoleStep
-              value={form.role}
-              error={errors.role}
-              onChange={r => { update('role', r); setError('role', undefined); }}
-            />
-          )}
-          {stepKey === 'identity' && (
-            <IdentityStep
-              fullName={form.fullName}
-              gender={form.gender}
-              error={errors.identity}
-              onFullName={t => update('fullName', t)}
-              onPickGender={() => setGenderSheet(true)}
-            />
-          )}
-          {stepKey === 'dob'      && (
-            <DobStep
-              day={form.dobDay} month={form.dobMonth} year={form.dobYear}
-              age={dobAge}
-              error={errors.dob}
-              roleRequiresAge18={form.role === 'donor' || form.role === 'both'}
-              shownPicker={form.dobShownPicker}
-              pickerDate={form.dobPickerDate}
-              onDay={t => update('dobDay', t.replace(/\D/g, '').slice(0, 2))}
-              onMonth={t => update('dobMonth', t.replace(/\D/g, '').slice(0, 2))}
-              onYear={t => update('dobYear', t.replace(/\D/g, '').slice(0, 4))}
-              onOpenPicker={() => update('dobShownPicker', true)}
-              onPickerChange={handlePickerChange}
-            />
-          )}
-          {stepKey === 'blood'    && (
-            <BloodStep
-              value={form.bloodGroup}
-              error={errors.blood}
-              onChange={g => { update('bloodGroup', g); setError('blood', undefined); }}
-            />
-          )}
-          {stepKey === 'medical'  && (
-            <MedicalStep
-              conditions={form.conditions}
-              share={form.shareMedical}
-              onToggleCondition={c => {
-                const next = form.conditions.includes(c)
-                  ? form.conditions.filter(x => x !== c)
-                  : [...form.conditions, c];
-                update('conditions', next);
-              }}
-              onToggleShare={() => update('shareMedical', !form.shareMedical)}
-            />
-          )}
-          {stepKey === 'contact'  && (
-            <ContactStep
-              phone={form.phone} whatsapp={form.whatsapp}
-              error={errors.contact}
-              onPhone={t => update('phone', t)}
-              onToggleWA={() => update('whatsapp', !form.whatsapp)}
-            />
-          )}
-          {stepKey === 'confirm'  && (
-            <ConfirmStep form={form} dobAge={dobAge} />
-          )}
-        </Animated.View>
-      </ScrollView>
+        <View style={styles.sheetTop}>
+          <View style={[styles.accentStrip, { backgroundColor: theme.primary }]} />
+          <View style={[styles.handle, { backgroundColor: theme.borderStrong }]} />
+        </View>
 
-      {/* ── Bottom CTA ───────────────────────────────────────────────────── */}
-      <View style={[styles.cta, { paddingBottom: insets.bottom + Spacing[4] }]}>
-        <Button
-          label={ctaLabel}
-          onPress={next}
-          loading={loading}
-          fullWidth size="xl"
-          variant="primary"
-        />
-      </View>
+        <ScrollView
+          contentContainerStyle={{
+            paddingHorizontal: Spacing[5],
+            paddingBottom: insets.bottom + Spacing[8],
+            gap: Spacing[5],
+          }}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <Text style={[styles.sectionLabel, { color: theme.textMuted }]}>
+            {STEP_HEADLINE[stepKey]}
+          </Text>
+
+          <Animated.View
+            key={stepKey}
+            entering={SlideInRight.duration(Motion.duration.base)}
+            exiting={SlideOutLeft.duration(Motion.duration.fast)}
+            style={{ gap: Spacing[5] }}
+          >
+            {stepKey === 'role'     && (
+              <RoleStep
+                value={form.role}
+                error={errors.role}
+                onChange={r => {
+                  Haptics.selectionAsync().catch(() => {});
+                  update('role', r); setError('role', undefined);
+                }}
+              />
+            )}
+            {stepKey === 'identity' && (
+              <IdentityStep
+                fullName={form.fullName}
+                gender={form.gender}
+                error={errors.identity}
+                onFullName={t => update('fullName', t)}
+                onPickGender={() => { Haptics.selectionAsync().catch(() => {}); setGenderSheet(true); }}
+              />
+            )}
+            {stepKey === 'dob'      && (
+              <DobStep
+                day={form.dobDay} month={form.dobMonth} year={form.dobYear}
+                age={dobAge}
+                error={errors.dob}
+                roleRequiresAge18={form.role === 'donor' || form.role === 'both'}
+                shownPicker={form.dobShownPicker}
+                pickerDate={form.dobPickerDate}
+                onDay={t => update('dobDay', t.replace(/\D/g, '').slice(0, 2))}
+                onMonth={t => update('dobMonth', t.replace(/\D/g, '').slice(0, 2))}
+                onYear={t => update('dobYear', t.replace(/\D/g, '').slice(0, 4))}
+                onOpenPicker={() => update('dobShownPicker', true)}
+                onPickerChange={handlePickerChange}
+              />
+            )}
+            {stepKey === 'blood'    && (
+              <BloodStep
+                value={form.bloodGroup}
+                error={errors.blood}
+                onChange={g => {
+                  Haptics.selectionAsync().catch(() => {});
+                  update('bloodGroup', g); setError('blood', undefined);
+                }}
+              />
+            )}
+            {stepKey === 'medical'  && (
+              <MedicalStep
+                conditions={form.conditions}
+                share={form.shareMedical}
+                onToggleCondition={c => {
+                  Haptics.selectionAsync().catch(() => {});
+                  const nextC = form.conditions.includes(c)
+                    ? form.conditions.filter(x => x !== c)
+                    : [...form.conditions, c];
+                  update('conditions', nextC);
+                }}
+                onToggleShare={() => {
+                  Haptics.selectionAsync().catch(() => {});
+                  update('shareMedical', !form.shareMedical);
+                }}
+              />
+            )}
+            {stepKey === 'contact'  && (
+              <ContactStep
+                phone={form.phone} whatsapp={form.whatsapp}
+                error={errors.contact}
+                onPhone={t => update('phone', t)}
+                onToggleWA={() => {
+                  Haptics.selectionAsync().catch(() => {});
+                  update('whatsapp', !form.whatsapp);
+                }}
+              />
+            )}
+            {stepKey === 'confirm'  && (
+              <ConfirmStep form={form} dobAge={dobAge} />
+            )}
+          </Animated.View>
+
+          {/* ── Inline CTA (ACT) ─────────────────────────────────────────── */}
+          <View style={styles.ctaInline}>
+            <View style={styles.ctaSummary}>
+              <View style={[styles.ctaSummaryDot, { backgroundColor: isFinal ? theme.success : theme.primary }]} />
+              <Text style={[styles.ctaSummaryText, { color: theme.textPrimary }]} numberOfLines={1}>
+                <Text style={{ fontWeight: FontWeight.black, color: isFinal ? theme.success : theme.primary }}>
+                  {isFinal ? 'Confirm' : `Step ${stepIdx + 1}/${totalSteps}`}
+                </Text>
+                <Text style={{ color: theme.textMuted }}>{'  ·  '}</Text>
+                <Text>{ctaSummaryLine}</Text>
+              </Text>
+            </View>
+
+            <BreathingWrapper enabled={isFinal && !loading}>
+              <Button
+                label={STEP_CTA[stepKey]}
+                onPress={next}
+                loading={loading}
+                fullWidth size="xl"
+                variant="primary"
+                haptic={false}
+                icon={
+                  <Ionicons
+                    name={isFinal ? 'shield-checkmark' : 'arrow-forward'}
+                    size={18}
+                    color={theme.textOnPrimary}
+                  />
+                }
+                iconPosition={isFinal ? 'left' : 'right'}
+              />
+            </BreathingWrapper>
+
+            <Text style={[styles.ctaFooterNote, { color: theme.textTertiary }]}>
+              {isFinal
+                ? 'By saving, you agree contact details are only shared after a match. You can edit anything later in Settings.'
+                : 'You can change any answer later from your profile.'}
+            </Text>
+          </View>
+        </ScrollView>
+      </Animated.View>
 
       <SelectSheet
         visible={genderSheet}
@@ -364,7 +490,7 @@ export default function OnboardingScreen() {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-// Step components — co-located, theme-aware, no emoji.
+// Step sub-components — theme-token only, no emoji, haptic-wired via parent.
 // ──────────────────────────────────────────────────────────────────────────────
 
 function RoleStep({
@@ -378,11 +504,13 @@ function RoleStep({
   ];
 
   return (
-    <View style={{ gap: Spacing[5] }}>
+    <View style={{ gap: Spacing[3] }}>
       <Text style={titleStyles(theme).title}>How will you use BludStack?</Text>
-      <Text style={titleStyles(theme).subtitle}>Pick what fits today. You can change this later in Settings.</Text>
+      <Text style={titleStyles(theme).subtitle}>
+        Pick what fits today. You can change this later in Settings.
+      </Text>
 
-      <View style={{ gap: Spacing[3], marginTop: Spacing[3] }}>
+      <View style={{ gap: Spacing[3], marginTop: Spacing[2] }}>
         {options.map(opt => {
           const selected = value === opt.value;
           return (
@@ -426,9 +554,7 @@ function RoleStep({
         })}
       </View>
 
-      {error && (
-        <Text style={[helperStyle(theme).err, { marginTop: Spacing[1] }]}>{error}</Text>
-      )}
+      {error && <Text style={[helperStyle(theme).err, { marginTop: Spacing[1] }]}>{error}</Text>}
     </View>
   );
 }
@@ -441,7 +567,7 @@ function IdentityStep({
 }) {
   const { theme } = useTheme();
   return (
-    <View style={{ gap: Spacing[5] }}>
+    <View style={{ gap: Spacing[3] }}>
       <Text style={titleStyles(theme).title}>What should we call you?</Text>
       <Text style={titleStyles(theme).subtitle}>
         Donors and recipients see this when they're matched with you.
@@ -456,6 +582,7 @@ function IdentityStep({
         autoComplete="name"
         textContentType="name"
         returnKeyType="next"
+        leftIcon={<Ionicons name="person-outline" size={18} color={theme.textMuted} />}
       />
 
       <Pressable onPress={onPickGender} accessibilityRole="button" accessibilityLabel="Pick gender">
@@ -465,6 +592,7 @@ function IdentityStep({
             placeholder="Select"
             value={gender}
             editable={false}
+            leftIcon={<Ionicons name="male-female-outline" size={18} color={theme.textMuted} />}
             rightIcon={<Ionicons name="chevron-down" size={18} color={theme.textMuted} />}
           />
         </View>
@@ -492,7 +620,7 @@ function DobStep({
   const showHelper = age !== null;
 
   return (
-    <View style={{ gap: Spacing[5] }}>
+    <View style={{ gap: Spacing[3] }}>
       <Text style={titleStyles(theme).title}>When were you born?</Text>
       <Text style={titleStyles(theme).subtitle}>
         {roleRequiresAge18
@@ -563,7 +691,7 @@ function BloodStep({
 }: { value: BloodGroup | ''; error?: string; onChange: (g: BloodGroup) => void }) {
   const { theme } = useTheme();
   return (
-    <View style={{ gap: Spacing[5] }}>
+    <View style={{ gap: Spacing[3] }}>
       <Text style={titleStyles(theme).title}>What's your blood group?</Text>
       <Text style={titleStyles(theme).subtitle}>
         We match donors and recipients on compatibility. If you don't know, ask your doctor or check your last donation card.
@@ -582,7 +710,7 @@ function BloodStep({
                   borderColor: selected ? theme.primary : theme.border,
                   backgroundColor: selected ? theme.primary : theme.cardElevated,
                 },
-                Elevation.xs,
+                selected && Elevation.sm,
               ]}
               accessibilityRole="radio"
               accessibilityState={{ selected }}
@@ -612,7 +740,7 @@ function MedicalStep({
 }) {
   const { theme } = useTheme();
   return (
-    <View style={{ gap: Spacing[5] }}>
+    <View style={{ gap: Spacing[3] }}>
       <Text style={titleStyles(theme).title}>Any conditions a recipient should know about?</Text>
       <Text style={titleStyles(theme).subtitle}>
         Tap anything that applies. We only share these with a recipient if you turn sharing on below.
@@ -647,29 +775,13 @@ function MedicalStep({
         })}
       </View>
 
-      <Pressable onPress={onToggleShare} style={[medStyles.shareRow, { borderColor: theme.border }]}>
-        <View style={{ flex: 1 }}>
-          <Text style={[medStyles.shareTitle, { color: theme.textPrimary }]}>
-            Share these with matched recipients
-          </Text>
-          <Text style={[medStyles.shareBody, { color: theme.textMuted }]}>
-            Off by default. Turn on only if you want recipients to see this before you donate.
-          </Text>
-        </View>
-        <View
-          style={[
-            medStyles.toggle,
-            { backgroundColor: share ? theme.primary : theme.cardElevated, borderColor: theme.border },
-          ]}
-        >
-          <View
-            style={[
-              medStyles.toggleDot,
-              { backgroundColor: theme.surface, transform: [{ translateX: share ? 22 : 2 }] },
-            ]}
-          />
-        </View>
-      </Pressable>
+      <ToggleSwitch
+        label="Share these with matched recipients"
+        description="Off by default. Turn on only if you want recipients to see this before you donate."
+        value={share}
+        onValueChange={() => onToggleShare()}
+        iconName="eye-outline"
+      />
     </View>
   );
 }
@@ -682,7 +794,7 @@ function ContactStep({
 }) {
   const { theme } = useTheme();
   return (
-    <View style={{ gap: Spacing[5] }}>
+    <View style={{ gap: Spacing[3] }}>
       <Text style={titleStyles(theme).title}>How can we reach you?</Text>
       <Text style={titleStyles(theme).subtitle}>
         Optional. A phone number lets a matched donor or recipient call you when seconds matter.
@@ -696,38 +808,17 @@ function ContactStep({
         keyboardType="phone-pad"
         autoComplete="tel"
         textContentType="telephoneNumber"
+        leftIcon={<Ionicons name="call-outline" size={18} color={theme.textMuted} />}
       />
 
-      <Pressable
-        onPress={onToggleWA}
+      <ToggleSwitch
+        label="I'm on WhatsApp"
+        description="Lets matched contacts open WhatsApp directly. Calls still work normally."
+        value={whatsapp}
         disabled={!phone.trim()}
-        style={[
-          medStyles.shareRow,
-          { borderColor: theme.border, opacity: phone.trim() ? 1 : 0.5 },
-        ]}
-      >
-        <View style={{ flex: 1 }}>
-          <Text style={[medStyles.shareTitle, { color: theme.textPrimary }]}>
-            I'm on WhatsApp
-          </Text>
-          <Text style={[medStyles.shareBody, { color: theme.textMuted }]}>
-            Lets matched contacts open WhatsApp directly. Calls still work normally.
-          </Text>
-        </View>
-        <View
-          style={[
-            medStyles.toggle,
-            { backgroundColor: whatsapp ? theme.success : theme.cardElevated, borderColor: theme.border },
-          ]}
-        >
-          <View
-            style={[
-              medStyles.toggleDot,
-              { backgroundColor: theme.surface, transform: [{ translateX: whatsapp ? 22 : 2 }] },
-            ]}
-          />
-        </View>
-      </Pressable>
+        onValueChange={() => onToggleWA()}
+        iconName="logo-whatsapp"
+      />
 
       {error && <Text style={helperStyle(theme).err}>{error}</Text>}
     </View>
@@ -737,10 +828,10 @@ function ContactStep({
 function ConfirmStep({ form, dobAge }: { form: FormState; dobAge: number | null }) {
   const { theme } = useTheme();
   const roleLabel =
-    form.role === 'donor'     ? 'Donor'
+    form.role === 'donor'       ? 'Donor'
     : form.role === 'recipient' ? 'Recipient'
-    : form.role === 'both'    ? 'Donor and recipient'
-    :                            '—';
+    : form.role === 'both'      ? 'Donor and recipient'
+    :                              '—';
 
   const rows: { label: string; value: string }[] = [
     { label: 'Role',          value: roleLabel },
@@ -757,7 +848,7 @@ function ConfirmStep({ form, dobAge }: { form: FormState; dobAge: number | null 
   ];
 
   return (
-    <View style={{ gap: Spacing[5] }}>
+    <View style={{ gap: Spacing[3] }}>
       <Text style={titleStyles(theme).title}>Last look — does this look right?</Text>
       <Text style={titleStyles(theme).subtitle}>
         Tap back to change anything. You can always edit your profile later.
@@ -785,7 +876,7 @@ function ConfirmStep({ form, dobAge }: { form: FormState; dobAge: number | null 
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-// Shared styles helpers
+// Shared style factories
 // ──────────────────────────────────────────────────────────────────────────────
 
 const titleStyles = (theme: ReturnType<typeof useTheme>['theme']) => StyleSheet.create({
@@ -809,9 +900,11 @@ const helperStyle = (theme: ReturnType<typeof useTheme>['theme']) => StyleSheet.
 
 const styles = StyleSheet.create({
   root: { flex: 1 },
-  header: {
+
+  // ── Hero ───────────────────────────────────────────────────────────────
+  hero: {
     paddingHorizontal: Spacing[5],
-    paddingBottom: Spacing[3],
+    paddingBottom: Spacing[10],
     gap: Spacing[3],
   },
   headerRow: {
@@ -825,19 +918,73 @@ const styles = StyleSheet.create({
   },
   stepCount: {
     fontSize: FontSize.xs,
-    fontWeight: FontWeight.bold,
-    letterSpacing: LetterSpacing.wider,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
     textTransform: 'uppercase',
   },
-  progressTrack: { height: 3, borderRadius: Radius.pill, overflow: 'hidden' },
+  progressTrack: { height: 4, borderRadius: Radius.pill, overflow: 'hidden' },
   progressFill:  { height: '100%', borderRadius: Radius.pill },
+  heroPill: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row', alignItems: 'center', gap: Spacing[2],
+    paddingHorizontal: Spacing[3], paddingVertical: Spacing[2],
+    borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
+    marginTop: Spacing[1],
+  },
+  heroPillDot: { width: 6, height: 6, borderRadius: 3 },
+  heroPillText: {
+    fontSize: FontSize['2xs'],
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
+    textTransform: 'uppercase',
+  },
 
-  scroll: { paddingHorizontal: Spacing[5], paddingVertical: Spacing[5] },
-  stepWrap: { gap: Spacing[5] },
+  // ── Sheet ──────────────────────────────────────────────────────────────
+  sheet: {
+    flex: 1,
+    borderTopLeftRadius:  Radius['2xl'],
+    borderTopRightRadius: Radius['2xl'],
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  sheetTop: { alignItems: 'center', paddingTop: Spacing[2], paddingBottom: Spacing[3] },
+  accentStrip: {
+    width: 36, height: 3, borderRadius: 2, marginBottom: Spacing[1],
+    opacity: 0.9,
+  },
+  handle: { width: 44, height: 4, borderRadius: 2 },
 
-  cta: {
-    paddingHorizontal: Spacing[5],
-    paddingTop: Spacing[3],
+  sectionLabel: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
+    textTransform: 'uppercase',
+    marginLeft: Spacing[2],
+  },
+
+  // ── In-form CTA ────────────────────────────────────────────────────────
+  ctaInline: {
+    marginTop: Spacing[2],
+    gap: Spacing[3],
+  },
+  ctaSummary: {
+    flexDirection: 'row', alignItems: 'center',
+    gap: Spacing[2],
+    paddingHorizontal: Spacing[1],
+  },
+  ctaSummaryDot: { width: 8, height: 8, borderRadius: 4 },
+  ctaSummaryText: {
+    flex: 1,
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.bold,
+    letterSpacing: LetterSpacing.snug,
+  },
+  ctaFooterNote: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.medium,
+    letterSpacing: LetterSpacing.snug,
+    textAlign: 'center',
+    paddingHorizontal: Spacing[4],
+    lineHeight: FontSize.xs * 1.5,
   },
 });
 
@@ -870,16 +1017,17 @@ const bloodStyles = StyleSheet.create({
   grid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: Spacing[3],
+    gap: Spacing[2],
   },
   cell: {
-    width: '22%', minWidth: 76, aspectRatio: 1,
+    width: '23%',
+    paddingVertical: Spacing[4],
     alignItems: 'center', justifyContent: 'center',
-    borderRadius: Radius.lg,
+    borderRadius: Radius.xl,
     borderWidth: 1.5,
   },
   label: {
-    fontSize: FontSize.xl,
+    fontSize: FontSize.lg,
     fontWeight: FontWeight.black,
     letterSpacing: LetterSpacing.tight,
   },
@@ -903,7 +1051,7 @@ const medStyles = StyleSheet.create({
     alignItems: 'center',
     gap: Spacing[3],
     padding: Spacing[4],
-    borderRadius: Radius.lg,
+    borderRadius: Radius.xl,
     borderWidth: StyleSheet.hairlineWidth,
   },
   shareTitle: {

--- a/mobile/app/profile/edit.tsx
+++ b/mobile/app/profile/edit.tsx
@@ -1,0 +1,730 @@
+// app/profile/edit.tsx
+// ──────────────────────────────────────────────────────────────────────────────
+// Request-screen design language for profile edit:
+//   • Hero zone with close + title + brand-accent context pill.
+//   • Sheet ascends -Spacing[5] over the hero with brand accent strip + handle
+//     + spring entrance (same physics as the post-request flow).
+//   • Bare sections under uppercase SectionLabel — no card wrappers.
+//   • Blood-group 4×n grid identical to Request screen.
+//   • Inline CTA at the end of the form: summary row + pill button + footer
+//     micro-copy.
+//   • Haptics on every choice. Reanimated worklets only.
+//
+// All fields go through apiUpdateProfile -> backend ALLOWED_FIELDS.
+// Server-managed fields (push_token, total_donations, last_donation_date,
+// is_verified) are not editable here — they're maintained by the server.
+// ──────────────────────────────────────────────────────────────────────────────
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  KeyboardAvoidingView, Platform, Pressable, ScrollView, StyleSheet, Text, View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+import Animated, {
+  useAnimatedStyle, useSharedValue, withSpring, withTiming, Easing,
+} from 'react-native-reanimated';
+import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useAuth, computeAge, type UserRole } from '@/contexts/AuthContext';
+import { useToast } from '@/contexts/ToastContext';
+import Button from '@/components/Button';
+import Input from '@/components/Input';
+import SelectSheet from '@/components/SelectSheet';
+import ToggleSwitch from '@/components/ToggleSwitch';
+import {
+  BLOOD_GROUPS, GENDER_OPTIONS, MEDICAL_CONDITIONS, type BloodGroup,
+} from '@/constants/BloodData';
+import {
+  FontSize, FontWeight, LetterSpacing, Spacing, Radius, Elevation,
+} from '@/constants/Typography';
+import { errorReporter } from '@/lib/errorReporter';
+
+const MIN_DONOR_AGE = 18;
+
+// Sheet entrance — identical physics to Request screen and onboarding.
+function useSheetEntrance() {
+  const ty = useSharedValue(60);
+  const op = useSharedValue(0);
+  useEffect(() => {
+    ty.value = withSpring(0, { damping: 16, stiffness: 180, mass: 0.6 });
+    op.value = withTiming(1, { duration: 280, easing: Easing.out(Easing.quad) });
+  }, [ty, op]);
+  return useAnimatedStyle(() => ({
+    transform: [{ translateY: ty.value }],
+    opacity: op.value,
+  }));
+}
+
+export default function ProfileEditScreen() {
+  const { theme } = useTheme();
+  const { profile, updateProfile, refreshProfile } = useAuth();
+  const toast  = useToast();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  // DOB is intentionally null when the user has never set it. Defaulting to
+  // a fake date (e.g. 2000-01-01) would silently bypass the donor-age gate —
+  // a donor could save without ever picking their real birthday and the
+  // server would treat them as eligible. Null forces an explicit pick.
+  const initialDob = useMemo<Date | null>(() => {
+    if (!profile?.date_of_birth) return null;
+    const d = new Date(profile.date_of_birth);
+    return isNaN(d.getTime()) ? null : d;
+  }, [profile?.date_of_birth]);
+
+  const [fullName,    setFullName]    = useState(profile?.full_name ?? '');
+  const [gender,      setGender]      = useState(profile?.gender ?? '');
+  const [genderSheet, setGenderSheet] = useState(false);
+  const [bloodGroup,  setBloodGroup]  = useState<BloodGroup | ''>((profile?.blood_group as BloodGroup) ?? '');
+  const [phone,       setPhone]       = useState(profile?.phone ?? '');
+  const [whatsapp,    setWhatsapp]    = useState(profile?.whatsapp_available ?? false);
+  const [address,     setAddress]     = useState(profile?.address ?? '');
+  const [conditions,  setConditions]  = useState<string[]>(profile?.medical_conditions ?? []);
+  const [share,       setShare]       = useState(profile?.share_medical_history ?? false);
+  const [available,   setAvailable]   = useState(profile?.is_available_to_donate ?? true);
+  const [role,        setRole]        = useState<UserRole>((profile?.role as UserRole) ?? 'donor');
+  const [dob,         setDob]         = useState<Date | null>(initialDob);
+  const [pickerOpen,  setPickerOpen]  = useState(false);
+  const [saving,      setSaving]      = useState(false);
+  const [error,       setError]       = useState<string | null>(null);
+
+  const dobIso = useCallback((): string | null => {
+    return dob ? dob.toISOString().slice(0, 10) : null;
+  }, [dob]);
+
+  const age = useMemo(() => computeAge(dobIso()), [dobIso]);
+
+  const onPickerChange = (event: DateTimePickerEvent, date?: Date) => {
+    if (event.type === 'dismissed') { setPickerOpen(false); return; }
+    if (date) {
+      Haptics.selectionAsync().catch(() => {});
+      setDob(date);
+    }
+    if (Platform.OS !== 'ios') setPickerOpen(false);
+  };
+
+  const toggleCondition = useCallback((c: string) => {
+    Haptics.selectionAsync().catch(() => {});
+    setConditions(prev => prev.includes(c) ? prev.filter(x => x !== c) : [...prev, c]);
+  }, []);
+
+  const pickBlood = useCallback((g: BloodGroup) => {
+    Haptics.selectionAsync().catch(() => {});
+    setBloodGroup(g);
+  }, []);
+
+  const pickRole = useCallback((r: UserRole) => {
+    Haptics.selectionAsync().catch(() => {});
+    setRole(r);
+  }, []);
+
+  const toggleWA = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    setWhatsapp(v => !v);
+  }, []);
+
+  const toggleShare = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    setShare(v => !v);
+  }, []);
+
+  const toggleAvailable = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    setAvailable(v => !v);
+  }, []);
+
+  const openGender = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    setGenderSheet(true);
+  }, []);
+
+  const openDobPicker = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    setPickerOpen(true);
+  }, []);
+
+  const closeModal = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    router.back();
+  }, [router]);
+
+  const validate = useCallback((): string | null => {
+    if (fullName.trim().length < 2) return 'Tell us the name you go by';
+    if (!bloodGroup) return 'Select your blood group';
+    if (phone.trim() && phone.replace(/\D/g, '').length < 7) return 'Phone number looks too short';
+    if (role === 'donor' || role === 'both') {
+      if (!age || age < MIN_DONOR_AGE) return `Donors must be ${MIN_DONOR_AGE} or older`;
+    }
+    return null;
+  }, [fullName, bloodGroup, phone, role, age]);
+
+  const onSave = useCallback(async () => {
+    const err = validate();
+    if (err) { setError(err); return; }
+    setError(null);
+    setSaving(true);
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
+    try {
+      await updateProfile({
+        full_name:              fullName.trim(),
+        gender:                 gender || undefined,
+        date_of_birth:          dobIso(),
+        address:                address.trim() || null,
+        blood_group:            bloodGroup as BloodGroup,
+        phone:                  phone.trim() || null,
+        whatsapp_available:     phone.trim() ? whatsapp : false,
+        medical_conditions:     role === 'recipient' ? [] : conditions,
+        share_medical_history:  share,
+        is_available_to_donate: role === 'recipient' ? false : available,
+        role,
+      });
+      toast.success('Profile updated');
+      await refreshProfile();
+      router.back();
+    } catch (e: any) {
+      errorReporter.error(e, { screen: 'profile/edit' });
+      toast.error("Couldn't save profile", { description: e?.message ?? 'Try again' });
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    validate, fullName, gender, dobIso, address, bloodGroup,
+    phone, whatsapp, conditions, share, available, role,
+    updateProfile, refreshProfile, router, toast,
+  ]);
+
+  const sheetEntrance = useSheetEntrance();
+  const isDonorLike = role === 'donor' || role === 'both';
+
+  // Summary line for the CTA — mirrors Request screen.
+  const ctaSummary = useMemo(() => {
+    const parts = [
+      role === 'donor' ? 'Donor' : role === 'recipient' ? 'Recipient' : 'Both',
+      bloodGroup || '—',
+      fullName.trim() || 'no name',
+    ];
+    return parts.join('  ·  ');
+  }, [role, bloodGroup, fullName]);
+
+  if (!profile) {
+    return null;
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={[styles.root, { backgroundColor: theme.background }]}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      {/* ─────────────────────── HERO (DECIDE) ───────────────────────────── */}
+      <View style={[styles.hero, { paddingTop: Spacing[3], backgroundColor: theme.background }]}>
+        <View style={styles.headerRow}>
+          <Pressable onPress={closeModal} style={styles.backBtn} hitSlop={10} accessibilityLabel="Close">
+            <Ionicons name="close" size={22} color={theme.textPrimary} />
+          </Pressable>
+          <Text style={[styles.headerTitle, { color: theme.textMuted }]}>
+            Account · Profile
+          </Text>
+          <View style={{ width: 40 }} />
+        </View>
+
+        <Text style={[styles.heroTitle, { color: theme.textPrimary }]} numberOfLines={1}>
+          Edit your profile
+        </Text>
+        <Text style={[styles.heroSub, { color: theme.textMuted }]} numberOfLines={2}>
+          What you change here is what donors and recipients see when they're matched with you.
+        </Text>
+
+        {/* Status pill — parity with Request screen overlay pills */}
+        <View style={[styles.heroPill, { backgroundColor: theme.surface, borderColor: theme.border }, Elevation.sm]}>
+          <View style={[styles.heroPillDot, { backgroundColor: theme.primary }]} />
+          <Text style={[styles.heroPillText, { color: theme.textMuted }]} numberOfLines={1}>
+            Signed in as {profile.email}
+          </Text>
+        </View>
+      </View>
+
+      {/* ─────────────────────── SHEET (VERIFY) ──────────────────────────── */}
+      <Animated.View
+        style={[
+          styles.sheet,
+          {
+            backgroundColor: theme.surface,
+            borderTopColor: theme.border,
+            marginTop: -Spacing[5],
+          },
+          Elevation.lg,
+          sheetEntrance,
+        ]}
+      >
+        <View style={styles.sheetTop}>
+          <View style={[styles.accentStrip, { backgroundColor: theme.primary }]} />
+          <View style={[styles.handle, { backgroundColor: theme.borderStrong }]} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={{
+            paddingHorizontal: Spacing[5],
+            paddingBottom: insets.bottom + Spacing[8],
+            gap: Spacing[5],
+          }}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {/* ── Identity ─────────────────────────────────────────────── */}
+          <View>
+            <SectionLabel theme={theme}>Identity</SectionLabel>
+            <View style={{ gap: Spacing[3] }}>
+              <Input
+                label="Full name"
+                value={fullName}
+                onChangeText={setFullName}
+                autoCapitalize="words"
+                autoComplete="name"
+                textContentType="name"
+                leftIcon={<Ionicons name="person-outline" size={18} color={theme.textMuted} />}
+              />
+
+              <Pressable onPress={openGender} accessibilityRole="button" accessibilityLabel="Pick gender">
+                <View pointerEvents="none">
+                  <Input
+                    label="Gender"
+                    value={gender}
+                    editable={false}
+                    placeholder="Select"
+                    leftIcon={<Ionicons name="male-female-outline" size={18} color={theme.textMuted} />}
+                    rightIcon={<Ionicons name="chevron-down" size={18} color={theme.textMuted} />}
+                  />
+                </View>
+              </Pressable>
+
+              <Pressable onPress={openDobPicker} accessibilityRole="button" accessibilityLabel="Pick date of birth">
+                <View pointerEvents="none">
+                  <Input
+                    label="Date of birth"
+                    value={dob ? dob.toLocaleDateString() : ''}
+                    placeholder="Tap to pick"
+                    editable={false}
+                    leftIcon={<Ionicons name="calendar-outline" size={18} color={theme.textMuted} />}
+                    rightIcon={<Ionicons name="chevron-down" size={18} color={theme.textMuted} />}
+                  />
+                </View>
+              </Pressable>
+
+              {pickerOpen && (
+                <DateTimePicker
+                  // DateTimePicker requires a non-null value, so we fall back
+                  // to today when the user has never picked. The fallback is
+                  // NEVER written back into `dob` state — it just primes the
+                  // picker UI. `onPickerChange` only setDob() when the user
+                  // explicitly picks (event.type !== 'dismissed').
+                  value={dob ?? new Date()}
+                  mode="date"
+                  display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+                  maximumDate={new Date()}
+                  minimumDate={new Date(1900, 0, 1)}
+                  onChange={onPickerChange}
+                />
+              )}
+            </View>
+          </View>
+
+          {/* ── Role (3 cards) ───────────────────────────────────────── */}
+          <View>
+            <SectionLabel theme={theme}>How will you use BludStack?</SectionLabel>
+            <View style={{ gap: Spacing[3] }}>
+              {ROLE_OPTIONS.map(o => {
+                const selected = role === o.v;
+                return (
+                  <Pressable
+                    key={o.v}
+                    onPress={() => pickRole(o.v)}
+                    style={[
+                      roleStyles.card,
+                      {
+                        borderColor: selected ? theme.primary : theme.border,
+                        backgroundColor: selected ? theme.primarySoft : theme.cardElevated,
+                      },
+                      Elevation.xs,
+                    ]}
+                    accessibilityRole="radio"
+                    accessibilityState={{ selected }}
+                  >
+                    <View
+                      style={[
+                        roleStyles.iconPill,
+                        { backgroundColor: selected ? theme.primary : theme.surface },
+                      ]}
+                    >
+                      <Ionicons
+                        name={o.icon}
+                        size={18}
+                        color={selected ? theme.textOnPrimary : theme.textPrimary}
+                      />
+                    </View>
+                    <Text style={[roleStyles.label, { color: theme.textPrimary }]}>{o.label}</Text>
+                    <Ionicons
+                      name={selected ? 'radio-button-on' : 'radio-button-off'}
+                      size={20}
+                      color={selected ? theme.primary : theme.textTertiary}
+                    />
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
+
+          {/* ── Blood group (4×n grid — identical to Request screen) ── */}
+          <View>
+            <SectionLabel theme={theme}>Blood group</SectionLabel>
+            <View style={bloodStyles.grid}>
+              {BLOOD_GROUPS.map(g => {
+                const selected = bloodGroup === g;
+                return (
+                  <Pressable
+                    key={g}
+                    onPress={() => pickBlood(g)}
+                    style={[
+                      bloodStyles.cell,
+                      {
+                        borderColor: selected ? theme.primary : theme.border,
+                        backgroundColor: selected ? theme.primary : theme.cardElevated,
+                      },
+                      selected && Elevation.sm,
+                    ]}
+                    accessibilityRole="radio"
+                    accessibilityState={{ selected }}
+                    accessibilityLabel={`Blood group ${g}`}
+                  >
+                    <Text style={[
+                      bloodStyles.label,
+                      { color: selected ? theme.textOnPrimary : theme.textPrimary },
+                    ]}>{g}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
+
+          {/* ── Contact ──────────────────────────────────────────────── */}
+          <View>
+            <SectionLabel theme={theme}>Contact</SectionLabel>
+            <View style={{ gap: Spacing[3] }}>
+              <Input
+                label="Phone"
+                value={phone}
+                onChangeText={setPhone}
+                keyboardType="phone-pad"
+                autoComplete="tel"
+                textContentType="telephoneNumber"
+                placeholder="+92 300 1234567"
+                leftIcon={<Ionicons name="call-outline" size={18} color={theme.textMuted} />}
+              />
+              <ToggleSwitch
+                label="I'm on WhatsApp"
+                description="Matched contacts can open WhatsApp instead of calling"
+                value={whatsapp}
+                disabled={!phone.trim()}
+                onValueChange={() => toggleWA()}
+                iconName="logo-whatsapp"
+              />
+              <Input
+                label="Address"
+                value={address}
+                onChangeText={setAddress}
+                placeholder="Street, area, city — for hospital staff who call you back"
+                autoCapitalize="sentences"
+                autoComplete="postal-address"
+                variant="area"
+                multiline
+                leftIcon={<Ionicons name="location-outline" size={18} color={theme.textMuted} />}
+              />
+            </View>
+          </View>
+
+          {/* ── Medical history (donor / both only) ──────────────────── */}
+          {isDonorLike && (
+            <View>
+              <SectionLabel theme={theme}>Medical history (optional)</SectionLabel>
+              <View style={medStyles.wrap}>
+                {MEDICAL_CONDITIONS.map(c => {
+                  const selected = conditions.includes(c);
+                  return (
+                    <Pressable
+                      key={c}
+                      onPress={() => toggleCondition(c)}
+                      style={[
+                        medStyles.chip,
+                        {
+                          borderColor: selected ? theme.primary : theme.border,
+                          backgroundColor: selected ? theme.primarySoft : theme.cardElevated,
+                        },
+                      ]}
+                      accessibilityRole="checkbox"
+                      accessibilityState={{ checked: selected }}
+                    >
+                      {selected && <Ionicons name="checkmark" size={14} color={theme.primary} />}
+                      <Text style={[
+                        medStyles.chipLabel,
+                        { color: selected ? theme.primary : theme.textPrimary, marginLeft: selected ? 4 : 0 },
+                      ]}>{c}</Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+              <View style={{ marginTop: Spacing[3] }}>
+                <ToggleSwitch
+                  label="Share these with matched recipients"
+                  description="Off by default. On lets recipients see your disclosed conditions before you donate."
+                  value={share}
+                  onValueChange={() => toggleShare()}
+                  iconName="eye-outline"
+                />
+              </View>
+            </View>
+          )}
+
+          {/* ── Availability (donor / both only) ─────────────────────── */}
+          {isDonorLike && (
+            <View>
+              <SectionLabel theme={theme}>Availability</SectionLabel>
+              <ToggleSwitch
+                label="Available to donate"
+                description="Receive alerts when a compatible request comes in near you"
+                value={available}
+                onValueChange={() => toggleAvailable()}
+                iconName="pulse-outline"
+              />
+            </View>
+          )}
+
+          {error && (
+            <View style={[styles.errPill, { backgroundColor: theme.dangerSoft, borderColor: theme.danger }]}>
+              <Ionicons name="warning" size={14} color={theme.danger} />
+              <Text style={[styles.errText, { color: theme.danger }]}>{error}</Text>
+            </View>
+          )}
+
+          {/* ── Inline CTA (ACT) — matches Request screen ────────────── */}
+          <View style={styles.ctaInline}>
+            <View style={styles.ctaSummary}>
+              <View style={[styles.ctaSummaryDot, { backgroundColor: theme.primary }]} />
+              <Text style={[styles.ctaSummaryText, { color: theme.textPrimary }]} numberOfLines={1}>
+                <Text style={{ fontWeight: FontWeight.black, color: theme.primary }}>Save</Text>
+                <Text style={{ color: theme.textMuted }}>{'  ·  '}</Text>
+                <Text>{ctaSummary}</Text>
+              </Text>
+            </View>
+
+            <Button
+              label="Save changes"
+              onPress={onSave}
+              loading={saving}
+              fullWidth size="xl"
+              variant="primary"
+              haptic={false}
+              icon={<Ionicons name="checkmark-circle" size={18} color={theme.textOnPrimary} />}
+              iconPosition="left"
+            />
+
+            <Text style={[styles.ctaFooterNote, { color: theme.textTertiary }]}>
+              We never share your number, address, or medical history with anyone until a donor accepts a request you've posted.
+            </Text>
+          </View>
+        </ScrollView>
+      </Animated.View>
+
+      <SelectSheet
+        visible={genderSheet}
+        title="Gender"
+        options={GENDER_OPTIONS.map(g => ({ label: g, value: g }))}
+        value={gender}
+        onSelect={v => { setGender(String(v)); setGenderSheet(false); }}
+        onClose={() => setGenderSheet(false)}
+      />
+    </KeyboardAvoidingView>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Section label — same shape as Request screen's local SectionLabel.
+// ──────────────────────────────────────────────────────────────────────────────
+function SectionLabel({ theme, children }: { theme: any; children: React.ReactNode }) {
+  return (
+    <Text style={{
+      fontSize: FontSize.xs,
+      fontWeight: FontWeight.black,
+      letterSpacing: LetterSpacing.widest,
+      textTransform: 'uppercase',
+      color: theme.textMuted,
+      marginLeft: Spacing[2],
+      marginBottom: Spacing[2],
+    }}>{children}</Text>
+  );
+}
+
+const ROLE_OPTIONS: { v: UserRole; label: string; icon: keyof typeof Ionicons.glyphMap }[] = [
+  { v: 'donor',     label: 'Donor only',                icon: 'water'  },
+  { v: 'recipient', label: 'Recipient only',            icon: 'medkit' },
+  { v: 'both',      label: 'Both — donor and recipient', icon: 'sync'   },
+];
+
+const styles = StyleSheet.create({
+  root: { flex: 1 },
+
+  // ── Hero ───────────────────────────────────────────────────────────────
+  hero: {
+    paddingHorizontal: Spacing[5],
+    paddingBottom: Spacing[10],
+    gap: Spacing[3],
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: Spacing[3],
+  },
+  backBtn: {
+    width: 40, height: 40, borderRadius: Radius.pill,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  headerTitle: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
+    textTransform: 'uppercase',
+  },
+  heroTitle: {
+    fontSize: FontSize['2xl'],
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.tighter,
+  },
+  heroSub: {
+    fontSize: FontSize.sm,
+    lineHeight: FontSize.sm * 1.5,
+    marginTop: Spacing[1],
+  },
+  heroPill: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row', alignItems: 'center', gap: Spacing[2],
+    paddingHorizontal: Spacing[3], paddingVertical: Spacing[2],
+    borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
+    marginTop: Spacing[2], maxWidth: '100%',
+  },
+  heroPillDot: { width: 6, height: 6, borderRadius: 3 },
+  heroPillText: {
+    fontSize: FontSize['2xs'],
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest,
+    textTransform: 'uppercase',
+    flexShrink: 1,
+  },
+
+  // ── Sheet ──────────────────────────────────────────────────────────────
+  sheet: {
+    flex: 1,
+    borderTopLeftRadius:  Radius['2xl'],
+    borderTopRightRadius: Radius['2xl'],
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  sheetTop: { alignItems: 'center', paddingTop: Spacing[2], paddingBottom: Spacing[3] },
+  accentStrip: {
+    width: 36, height: 3, borderRadius: 2, marginBottom: Spacing[1],
+    opacity: 0.9,
+  },
+  handle: { width: 44, height: 4, borderRadius: 2 },
+
+  // ── Error pill ─────────────────────────────────────────────────────────
+  errPill: {
+    flexDirection: 'row', alignItems: 'center', gap: Spacing[2],
+    paddingHorizontal: Spacing[3], paddingVertical: Spacing[2],
+    borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
+    alignSelf: 'flex-start',
+  },
+  errText: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.bold,
+    letterSpacing: LetterSpacing.snug,
+  },
+
+  // ── In-form CTA ────────────────────────────────────────────────────────
+  ctaInline: {
+    marginTop: Spacing[2],
+    gap: Spacing[3],
+  },
+  ctaSummary: {
+    flexDirection: 'row', alignItems: 'center',
+    gap: Spacing[2],
+    paddingHorizontal: Spacing[1],
+  },
+  ctaSummaryDot: { width: 8, height: 8, borderRadius: 4 },
+  ctaSummaryText: {
+    flex: 1,
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.bold,
+    letterSpacing: LetterSpacing.snug,
+  },
+  ctaFooterNote: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.medium,
+    letterSpacing: LetterSpacing.snug,
+    textAlign: 'center',
+    paddingHorizontal: Spacing[4],
+    lineHeight: FontSize.xs * 1.5,
+  },
+});
+
+const roleStyles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing[3],
+    paddingVertical: Spacing[3],
+    paddingHorizontal: Spacing[4],
+    borderRadius: Radius.xl,
+    borderWidth: 1.5,
+  },
+  iconPill: {
+    width: 36, height: 36, borderRadius: Radius.pill,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  label: {
+    flex: 1,
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.bold,
+    letterSpacing: LetterSpacing.snug,
+  },
+});
+
+const bloodStyles = StyleSheet.create({
+  grid: { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing[2] },
+  cell: {
+    width: '23%',
+    paddingVertical: Spacing[4],
+    alignItems: 'center', justifyContent: 'center',
+    borderRadius: Radius.xl,
+    borderWidth: 1.5,
+  },
+  label: {
+    fontSize: FontSize.lg,
+    fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.tight,
+  },
+});
+
+const medStyles = StyleSheet.create({
+  wrap: { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing[2] },
+  chip: {
+    flexDirection: 'row', alignItems: 'center',
+    paddingVertical: Spacing[2], paddingHorizontal: Spacing[3],
+    borderRadius: Radius.pill, borderWidth: 1.5,
+  },
+  chipLabel: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.semibold,
+    letterSpacing: LetterSpacing.snug,
+  },
+});
+

--- a/mobile/app/request/[id].tsx
+++ b/mobile/app/request/[id].tsx
@@ -7,12 +7,14 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import MapView, { Marker, PROVIDER_DEFAULT } from 'react-native-maps';
+import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { Ionicons } from '@expo/vector-icons';
 import { supabase } from '@/utils/supabase';
 import { apiAcceptRequest, apiDeclineRequest, apiCompleteDonation, apiCancelRequest } from '@/utils/api';
 import { useToast } from '@/contexts/ToastContext';
+import { useDonorHeartbeat } from '@/hooks/useDonorHeartbeat';
 import { BloodRequest, RequestResponse } from '@/hooks/useRequests';
 import { useLocation } from '@/hooks/useLocation';
 import BloodGroupBadge from '@/components/BloodGroupBadge';
@@ -49,6 +51,18 @@ export default function RequestDetailScreen() {
   const [myResponse, setMyResponse]   = useState<RequestResponse | null>(null);
   const [loading, setLoading]         = useState(true);
   const [actionLoading, setActionLoading] = useState(false);
+  // One-active-commitment guard: the OTHER request_id this donor is already
+  // committed to (accepted + parent request still active). When set, the
+  // Accept CTA on this screen is replaced by a warning pill explaining why.
+  const [otherCommitmentId, setOtherCommitmentId] = useState<string | null>(null);
+
+  // Push donor's live GPS to backend while accepted + request still active.
+  // The recipient watches this via realtime UPDATEs on request_responses and
+  // renders the moving pin on /map/live.
+  useDonorHeartbeat(
+    id,
+    myResponse?.status === 'accepted' && request?.status === 'active',
+  );
 
   // Pulse animation for urgent requests
   const pulseAnim = useRef(new Animated.Value(1)).current;
@@ -112,9 +126,32 @@ export default function RequestDetailScreen() {
     }
   }, [id, user?.id]);
 
+  // Look up whether this donor is already committed to ANOTHER active request.
+  // The accept_blood_request RPC also enforces this server-side; we mirror it
+  // client-side so the UI shows a clear "you can't accept this yet" pill
+  // instead of letting the user tap Accept and read a server error.
+  const fetchOtherCommitment = useCallback(async () => {
+    if (!id || !user?.id) { setOtherCommitmentId(null); return; }
+    try {
+      const { data, error } = await supabase
+        .from('request_responses')
+        .select('request_id, blood_requests!inner(status)')
+        .eq('donor_id', user.id)
+        .eq('status', 'accepted')
+        .neq('request_id', id)
+        .eq('blood_requests.status', 'active')
+        .limit(1)
+        .maybeSingle();
+      if (error) throw error;
+      setOtherCommitmentId((data as any)?.request_id ?? null);
+    } catch (e: any) {
+      console.warn('[fetchOtherCommitment]', e.message);
+    }
+  }, [id, user?.id]);
+
   useEffect(() => {
     if (!id) return;
-    Promise.all([fetchRequest(), fetchResponses()]).finally(() => setLoading(false));
+    Promise.all([fetchRequest(), fetchResponses(), fetchOtherCommitment()]).finally(() => setLoading(false));
 
     // Real-time responses subscription — unique channel to avoid collision
     const channelName = uniqueChannelName(`req_detail_${id}`);
@@ -129,35 +166,61 @@ export default function RequestDetailScreen() {
         event: 'UPDATE', schema: 'public',
         table: 'blood_requests',
         filter: `id=eq.${id}`,
-      }, () => { fetchRequest(); })
+      }, () => { fetchRequest(); fetchOtherCommitment(); })
       .subscribe();
 
-    return () => { supabase.removeChannel(channel); };
-  }, [id]); // stable — fetchRequest/fetchResponses are stable via useCallback with no-dep pattern
+    // Also watch ALL of this user's responses globally so the other-commitment
+    // guard updates the moment a prior commitment is completed/cancelled.
+    let myResponsesChannel: ReturnType<typeof supabase.channel> | null = null;
+    if (user?.id) {
+      myResponsesChannel = supabase
+        .channel(uniqueChannelName(`my_resps_${user.id}`))
+        .on('postgres_changes', {
+          event: '*', schema: 'public',
+          table: 'request_responses',
+          filter: `donor_id=eq.${user.id}`,
+        }, () => { fetchOtherCommitment(); })
+        .subscribe();
+    }
+
+    return () => {
+      supabase.removeChannel(channel);
+      if (myResponsesChannel) supabase.removeChannel(myResponsesChannel);
+    };
+  }, [id, user?.id]); // stable — fetchRequest/fetchResponses/fetchOtherCommitment via useCallback
+
+  const openMaps = useCallback(() => {
+    if (!request) return;
+    Linking.openURL(
+      `https://www.google.com/maps/dir/?api=1&destination=${request.latitude},${request.longitude}&travelmode=driving`
+    );
+  }, [request]);
 
   // ── ACCEPT: backend RPC validates cooldown + capacity atomically (flaw #8) ──
   const handleAccept = useCallback(async () => {
     if (!user?.id || !id) return;
     setActionLoading(true);
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
     try {
       await apiAcceptRequest(id);
       await fetchResponses();
       await fetchRequest();
       Alert.alert(
-        '🩸 Request Accepted!',
-        `You have committed to donating. The recipient will be notified. Please head to the hospital immediately.`,
-        [{ text: 'Get Directions', onPress: openMaps }, { text: 'OK', style: 'cancel' }],
+        "You're on the way",
+        `You committed to donating. The recipient is being notified. Head to ${request?.hospital_name ?? 'the hospital'} as soon as you can.`,
+        [{ text: 'Open directions', onPress: openMaps }, { text: 'Later', style: 'cancel' }],
       );
     } catch (e: any) {
       Alert.alert('Failed to accept', e?.message ?? 'Please check your connection and try again.');
     } finally {
       setActionLoading(false);
     }
-  }, [user?.id, id, fetchResponses, fetchRequest, openMaps]);
+  }, [user?.id, id, fetchResponses, fetchRequest, openMaps, request?.hospital_name]);
 
   const handleDecline = useCallback(async () => {
     if (!user?.id || !id) return;
     setActionLoading(true);
+    Haptics.selectionAsync().catch(() => {});
     try {
       await apiDeclineRequest(id);
       await fetchResponses();
@@ -184,12 +247,13 @@ export default function RequestDetailScreen() {
           text: 'Yes, Fulfilled',
           onPress: async () => {
             setActionLoading(true);
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
             try {
               // Backend RPC: atomic flip request→fulfilled + response→completed
               // + donor.total_donations++ + donor.last_donation_date=now. Idempotent.
               await apiCompleteDonation(id, accepted.donor_id);
               await fetchRequest();
-              Alert.alert('🎉 Life Saved!', 'Donation recorded. Thank you for using BludStack.');
+              Alert.alert('Life saved', 'Donation recorded. Thank you for showing up.');
             } catch (e: any) {
               Alert.alert('Error', e?.message ?? 'Failed to mark fulfilled.');
             } finally {
@@ -201,29 +265,35 @@ export default function RequestDetailScreen() {
     );
   }, [id, user?.id, responses, fetchRequest]);
 
-  const openMaps = useCallback(() => {
-    if (!request) return;
-    Linking.openURL(
-      `https://www.google.com/maps/dir/?api=1&destination=${request.latitude},${request.longitude}&travelmode=driving`
-    );
-  }, [request]);
-
   const callContact = useCallback((contact: any) => {
     const phone = contact?.phone ?? contact?.email;
     if (phone) Linking.openURL(`tel:${phone}`);
   }, []);
 
+  // In-app chat scoped to this request — NEVER email. The mutual-commitment
+  // RLS guarantees both parties can resolve each other's profile, so the
+  // ProfileCard's Chat pill flows here without round-tripping a discovery query.
   const messageContact = useCallback((contact: any) => {
-    const email = contact?.email;
-    if (email) Linking.openURL(`mailto:${email}`);
-  }, []);
+    if (!contact?.id || !id) return;
+    Haptics.selectionAsync().catch(() => {});
+    router.push({
+      pathname: '/chat',
+      params: {
+        requestId:    String(id),
+        receiverId:   contact.id,
+        receiverName: encodeURIComponent(contact.full_name ?? 'User'),
+      },
+    } as any);
+  }, [id, router]);
 
   if (loading) return <LoadingScreen message="Loading request…" />;
   if (!request) return null;
 
   const urgencyColor  = URGENCY_COLORS[request.urgency] ?? '#E8002D';
   const urgencyConfig = URGENCY_CONFIG[request.urgency];
-  const isMyRequest   = request.recipient_id === user?.id;
+  // Defensive: if user.id hasn't hydrated yet (rare cold-start race), treat
+  // it as the recipient's request so we don't briefly render the accept CTA.
+  const isMyRequest   = !user?.id ? true : request.recipient_id === user.id;
 
   const distance = location
     ? haversineDistance(location.latitude, location.longitude, request.latitude, request.longitude)
@@ -249,7 +319,7 @@ export default function RequestDetailScreen() {
 
       {/* ── Top bar ── */}
       <View style={[styles.topBar, {
-        paddingTop: insets.top + Spacing[2],
+        paddingTop: Spacing[2],
         backgroundColor: theme.surface,
         borderBottomColor: theme.border,
       }]}>
@@ -358,7 +428,10 @@ export default function RequestDetailScreen() {
           </TouchableOpacity>
         </View>
 
-        {/* ── Recipient info (shown to accepted donor) ── */}
+        {/* ── Recipient info (shown to accepted donor) ──
+            ProfileCard already exposes Call / WhatsApp / Chat pills — no
+            duplicate "Message recipient" button beneath it. Single chat
+            affordance per profile. */}
         {!isMyRequest && myResponse?.status === 'accepted' && request.recipient && (
           <Section title="Recipient" theme={theme}>
             <ProfileCard
@@ -367,21 +440,21 @@ export default function RequestDetailScreen() {
               onMessage={() => messageContact(request.recipient)}
             />
             <Button
-              label="Message recipient"
-              variant="secondary"
+              label="View full profile"
+              variant="outline"
               size="lg"
               fullWidth
-              icon={<Ionicons name="chatbubble-ellipses-outline" size={18} color={theme.textPrimary} />}
-              onPress={() => router.push({
-                pathname: '/chat',
-                params: {
-                  requestId: String(id),
-                  receiverId: (request.recipient as any)?.id ?? request.recipient_id,
-                  receiverName: encodeURIComponent((request.recipient as any)?.full_name ?? 'Recipient'),
-                },
-              } as any)}
+              icon={<Ionicons name="person-circle-outline" size={18} color={theme.textPrimary} />}
+              onPress={() => {
+                Haptics.selectionAsync().catch(() => {});
+                const rid = (request.recipient as any)?.id ?? request.recipient_id;
+                router.push({
+                  pathname: `/donor/${rid}` as any,
+                  params:   { requestId: String(id) },
+                } as any);
+              }}
               style={{ marginTop: Spacing[3] }}
-              accessibilityHint="Open chat with the recipient about this request"
+              accessibilityHint="Open the recipient's full profile"
             />
           </Section>
         )}
@@ -393,29 +466,81 @@ export default function RequestDetailScreen() {
             theme={theme}
           >
             {acceptedResponses.map(resp => resp.donor && (
-              <View key={resp.id} style={{ gap: Spacing[3], marginBottom: Spacing[3] }}>
+              <View key={resp.id} style={{ gap: Spacing[3], marginBottom: Spacing[4] }}>
                 <ProfileCard
                   profile={resp.donor as any}
                   onCall={() => callContact(resp.donor)}
                   onMessage={() => messageContact(resp.donor)}
                 />
+
+                {/* Per-donor heartbeat status pill (recipient view).
+                    Shows whether THIS specific donor is sharing live GPS. */}
+                {(resp as any).donor_lat != null ? (
+                  <View style={[styles.liveWaitPill, { backgroundColor: theme.successSoft, borderColor: theme.success }]}>
+                    <View style={[styles.liveWaitDot, { backgroundColor: theme.success }]} />
+                    <Text style={[styles.liveWaitText, { color: theme.success }]} numberOfLines={1}>
+                      Live · sharing GPS right now
+                    </Text>
+                  </View>
+                ) : (
+                  <View style={[styles.liveWaitPill, { backgroundColor: theme.cardElevated, borderColor: theme.border }]}>
+                    <View style={[styles.liveWaitDot, { backgroundColor: theme.warning }]} />
+                    <Text style={[styles.liveWaitText, { color: theme.textMuted }]} numberOfLines={1}>
+                      Waiting for {(resp.donor as any).full_name?.split(' ')[0] ?? 'donor'} to share GPS
+                    </Text>
+                  </View>
+                )}
+
+                {/* No duplicate Message button — the ProfileCard's Chat pill
+                    already opens this thread via messageContact(). One chat
+                    affordance per profile. */}
                 <Button
-                  label={`Message ${(resp.donor as any).full_name?.split(' ')[0] ?? 'donor'}`}
-                  variant="secondary"
+                  label={`View ${(resp.donor as any).full_name?.split(' ')[0] ?? 'donor'}'s full profile`}
+                  variant="outline"
                   size="md"
                   fullWidth
-                  icon={<Ionicons name="chatbubble-ellipses-outline" size={16} color={theme.textPrimary} />}
-                  onPress={() => router.push({
-                    pathname: '/chat',
-                    params: {
-                      requestId: String(id),
-                      receiverId: (resp.donor as any).id,
-                      receiverName: encodeURIComponent((resp.donor as any).full_name ?? 'Donor'),
-                    },
-                  } as any)}
+                  icon={<Ionicons name="person-circle-outline" size={16} color={theme.textPrimary} />}
+                  onPress={() => {
+                    Haptics.selectionAsync().catch(() => {});
+                    router.push({
+                      pathname: `/donor/${(resp.donor as any).id}` as any,
+                      params:   { requestId: String(id) },
+                    } as any);
+                  }}
+                  accessibilityHint="Open the donor's full profile including donation history"
                 />
               </View>
             ))}
+
+            {/* Live tracking — always render once a donor accepts (Uber-driver
+                UX). When a heartbeat exists, the button is primary; until then
+                we show a soft "waiting for GPS" pill so the recipient knows
+                tracking is wired and pending, not missing. */}
+            {(() => {
+              const hasHeartbeat = acceptedResponses.some(r => (r as any).donor_lat != null);
+              return hasHeartbeat ? (
+                <Button
+                  label="Track donor live"
+                  variant="primary"
+                  size="lg"
+                  fullWidth
+                  icon={<Ionicons name="navigate" size={18} color={theme.textOnPrimary} />}
+                  onPress={() => router.push({
+                    pathname: '/map/live',
+                    params: { requestId: String(id), role: 'recipient' },
+                  } as any)}
+                  style={{ marginTop: Spacing[2] }}
+                  accessibilityHint="Open the live map showing donor locations"
+                />
+              ) : (
+                <View style={[styles.liveWaitPill, { backgroundColor: theme.cardElevated, borderColor: theme.border, marginTop: Spacing[2] }]}>
+                  <View style={[styles.liveWaitDot, { backgroundColor: theme.warning }]} />
+                  <Text style={[styles.liveWaitText, { color: theme.textMuted }]} numberOfLines={1}>
+                    Waiting for donor's GPS · Live tracking starts when they share their location
+                  </Text>
+                </View>
+              );
+            })()}
           </Section>
         )}
 
@@ -444,7 +569,9 @@ export default function RequestDetailScreen() {
             )}
 
             {myResponse?.status === 'accepted' ? (
-              /* Already accepted — confirmation state + chat unlock (peak-end) */
+              /* Already accepted — confirmation state (peak-end). Contact
+                 affordances live ONCE in the Recipient section below; this
+                 block stays focused on the immediate physical action. */
               <View style={[styles.acceptedState, { backgroundColor: theme.successSoft, borderColor: theme.success }]}>
                 <View style={[styles.successBadge, { backgroundColor: theme.success }]}>
                   <Ionicons name="checkmark" size={22} color={theme.textOnPrimary} />
@@ -461,22 +588,6 @@ export default function RequestDetailScreen() {
                   size="lg"
                   icon={<Ionicons name="navigate-outline" size={18} color={theme.textOnPrimary} />}
                 />
-                <Button
-                  label="Message recipient"
-                  variant="secondary"
-                  size="lg"
-                  fullWidth
-                  icon={<Ionicons name="chatbubble-ellipses-outline" size={18} color={theme.textPrimary} />}
-                  onPress={() => router.push({
-                    pathname: '/chat',
-                    params: {
-                      requestId: String(id),
-                      receiverId: (request.recipient as any)?.id ?? request.recipient_id,
-                      receiverName: encodeURIComponent((request.recipient as any)?.full_name ?? 'Recipient'),
-                    },
-                  } as any)}
-                  accessibilityHint="Open chat with the recipient about this request"
-                />
               </View>
             ) : myResponse?.status === 'declined' ? (
               <View style={[styles.declinedState, { backgroundColor: theme.cardElevated }]}>
@@ -488,6 +599,37 @@ export default function RequestDetailScreen() {
                   variant="outline"
                   onPress={handleAccept}
                   loading={actionLoading}
+                  fullWidth
+                />
+              </View>
+            ) : otherCommitmentId ? (
+              /* One-active-commitment block: donor is already committed to
+                 a different active request and must complete or release that
+                 one before accepting another. Server enforces the same rule
+                 in accept_blood_request; this is the kinder UX path. */
+              <View style={styles.ctaBlock}>
+                <View style={[styles.warnBanner, { backgroundColor: theme.warningSoft, borderColor: theme.warning }]}>
+                  <Ionicons name="alert-circle" size={18} color={theme.warning} />
+                  <Text style={[styles.infoBannerText, { color: theme.textSecondary, marginLeft: Spacing[2] }]}>
+                    You're already on the way to another donation. Finish that one — or release it — before accepting a new request.
+                  </Text>
+                </View>
+                <Button
+                  label="Open my active commitment"
+                  variant="primary"
+                  size="xl"
+                  fullWidth
+                  icon={<Ionicons name="navigate" size={18} color={theme.textOnPrimary} />}
+                  onPress={() => {
+                    Haptics.selectionAsync().catch(() => {});
+                    router.push(`/request/${otherCommitmentId}` as any);
+                  }}
+                />
+                <Button
+                  label="Not this time"
+                  variant="ghost"
+                  size="md"
+                  onPress={handleDecline}
                   fullWidth
                 />
               </View>
@@ -632,7 +774,7 @@ const styles = StyleSheet.create({
 
   scroll: { padding: Spacing[5], gap: Spacing[4] },
 
-  heroCard:   { borderRadius: Radius.md, borderWidth: 2, overflow: 'hidden' },
+  heroCard:   { borderRadius: Radius.xl, borderWidth: 2, overflow: 'hidden' },
   statusStripe: { height: 4 },
   heroInner:  { padding: Spacing[4], gap: Spacing[4] },
   heroTop:    { flexDirection: 'row', gap: Spacing[4], alignItems: 'flex-start' },
@@ -656,14 +798,14 @@ const styles = StyleSheet.create({
   etaValue:   { fontSize: FontSize.base, fontWeight: FontWeight.black },
   etaLabel:   { fontSize: FontSize['2xs'], fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.widest, textTransform: 'uppercase', marginTop: 2 },
   etaDivider: { width: StyleSheet.hairlineWidth, height: 28 },
-  dirBtn:     { paddingHorizontal: Spacing[3], paddingVertical: Spacing[2], borderRadius: Radius.xs },
+  dirBtn:     { paddingHorizontal: Spacing[3], paddingVertical: Spacing[2], borderRadius: Radius.pill },
   dirBtnText: { color: '#fff', fontSize: FontSize.xs, fontWeight: FontWeight.black },
 
-  notesBox:   { padding: Spacing[3], borderRadius: Radius.xs, borderWidth: StyleSheet.hairlineWidth },
+  notesBox:   { padding: Spacing[3], borderRadius: Radius.xl, borderWidth: StyleSheet.hairlineWidth },
   notesLabel: { fontSize: FontSize['2xs'], fontWeight: FontWeight.black, letterSpacing: LetterSpacing.widest, textTransform: 'uppercase', marginBottom: Spacing[1] },
   notesText:  { fontSize: FontSize.sm, lineHeight: 20 },
 
-  mapCard:    { borderRadius: Radius.md, borderWidth: StyleSheet.hairlineWidth, overflow: 'hidden', height: 180 },
+  mapCard:    { borderRadius: Radius.xl, borderWidth: StyleSheet.hairlineWidth, overflow: 'hidden', height: 180 },
   map:        { ...StyleSheet.absoluteFillObject },
   mapOverlay: {
     position: 'absolute', bottom: 0, left: 0, right: 0,
@@ -676,27 +818,34 @@ const styles = StyleSheet.create({
 
   infoBanner: {
     flexDirection: 'row', alignItems: 'flex-start', gap: Spacing[3],
-    padding: Spacing[3], borderRadius: Radius.sm, borderWidth: 1,
+    padding: Spacing[3], borderRadius: Radius.xl, borderWidth: 1,
   },
+  liveWaitPill: {
+    flexDirection: 'row', alignItems: 'center', gap: Spacing[2],
+    paddingHorizontal: Spacing[3], paddingVertical: Spacing[2],
+    borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
+  },
+  liveWaitDot: { width: 8, height: 8, borderRadius: 4 },
+  liveWaitText: { flex: 1, fontSize: FontSize.xs, fontWeight: FontWeight.semibold, letterSpacing: LetterSpacing.snug },
   infoBannerIcon: { fontSize: 18 },
   infoBannerText: { flex: 1, fontSize: FontSize.sm, lineHeight: 20 },
 
   warnBanner: {
     flexDirection: 'row', alignItems: 'flex-start', gap: Spacing[3],
-    padding: Spacing[3], borderRadius: Radius.sm, borderWidth: 1,
+    padding: Spacing[3], borderRadius: Radius.xl, borderWidth: 1,
   },
 
   actionWrap: { gap: Spacing[3] },
 
   ctaBlock: { gap: Spacing[3] },
   scarcityRow: {
-    padding: Spacing[3], borderRadius: Radius.sm, borderWidth: 1,
+    padding: Spacing[3], borderRadius: Radius.xl, borderWidth: 1,
   },
   scarcityText: { fontSize: FontSize.sm, fontWeight: FontWeight.semibold, lineHeight: 20 },
 
   acceptedState: {
     alignItems: 'center', gap: Spacing[3], padding: Spacing[5],
-    borderRadius: Radius.md, borderWidth: 1,
+    borderRadius: Radius.xl, borderWidth: 1,
   },
   acceptedEmoji: { fontSize: 40 },
   successBadge:  {
@@ -707,9 +856,9 @@ const styles = StyleSheet.create({
   acceptedTitle: { fontSize: FontSize.lg, fontWeight: FontWeight.black },
   acceptedSub:   { fontSize: FontSize.sm, textAlign: 'center', lineHeight: 20 },
 
-  declinedState: { gap: Spacing[3], padding: Spacing[4], borderRadius: Radius.sm, alignItems: 'center' },
+  declinedState: { gap: Spacing[3], padding: Spacing[4], borderRadius: Radius.xl, alignItems: 'center' },
   declinedText:  { fontSize: FontSize.sm, fontStyle: 'italic' },
 
-  closedBanner:  { padding: Spacing[4], borderRadius: Radius.sm, borderWidth: StyleSheet.hairlineWidth },
+  closedBanner:  { padding: Spacing[4], borderRadius: Radius.xl, borderWidth: StyleSheet.hairlineWidth },
   closedText:    { fontSize: FontSize.sm, textAlign: 'center', lineHeight: 20 },
 });

--- a/mobile/components/BloodGroupBadge.tsx
+++ b/mobile/components/BloodGroupBadge.tsx
@@ -1,58 +1,83 @@
 // components/BloodGroupBadge.tsx
+// Variants: solid (filled crimson, white text) | soft (tinted bg, crimson text)
+//           | outline (transparent, bordered) | ghost (no border, no fill)
+// Sizes:    xs | sm | md | lg | xl
+//
+// Pill-shaped, theme-tokenized. Reads from theme.primary so it follows the
+// active palette. No hardcoded hex.
+
 import React from 'react';
 import { View, Text, StyleSheet, ViewStyle } from 'react-native';
-import { getBloodGroupColor } from '@/utils/helpers';
-import { FontSize, FontWeight, Radius } from '@/constants/Typography';
+import { useTheme } from '@/contexts/ThemeContext';
+import { FontSize, FontWeight, LetterSpacing, Radius } from '@/constants/Typography';
 
-interface BloodGroupBadgeProps {
+export type BloodGroupBadgeVariant = 'solid' | 'soft' | 'outline' | 'ghost';
+export type BloodGroupBadgeSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+export interface BloodGroupBadgeProps {
   bloodGroup: string;
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  size?: BloodGroupBadgeSize;
+  variant?: BloodGroupBadgeVariant;
   style?: ViewStyle;
-  inverted?: boolean;  // solid bg
-  showGlow?: boolean;  // legacy compat — same as inverted
+  /** Legacy compat — true == solid. */
+  inverted?: boolean;
+  showGlow?: boolean;
 }
 
-const CFG = {
-  xs: { w: 32, h: 20, fs: FontSize['2xs'], br: Radius.xs },
-  sm: { w: 44, h: 26, fs: FontSize.xs, br: Radius.xs },
-  md: { w: 56, h: 32, fs: FontSize.sm, br: Radius.sm },
-  lg: { w: 72, h: 44, fs: FontSize.md, br: Radius.sm },
-  xl: { w: 88, h: 56, fs: FontSize.lg, br: Radius.base },
+const SIZE_CFG: Record<BloodGroupBadgeSize, { px: number; py: number; fs: number; minW: number }> = {
+  xs: { px: 8,  py: 3,  fs: FontSize['2xs'], minW: 34 },
+  sm: { px: 10, py: 4,  fs: FontSize.xs,     minW: 44 },
+  md: { px: 12, py: 6,  fs: FontSize.sm,     minW: 56 },
+  lg: { px: 16, py: 10, fs: FontSize.md,     minW: 72 },
+  xl: { px: 20, py: 14, fs: FontSize.lg,     minW: 88 },
 };
 
 const BloodGroupBadge = React.memo(function BloodGroupBadge({
-  bloodGroup, size = 'md', style, inverted = false, showGlow = false,
+  bloodGroup, size = 'md', variant, inverted, showGlow, style,
 }: BloodGroupBadgeProps) {
-  const solid = inverted || showGlow;
-  const color = getBloodGroupColor(bloodGroup);
-  const cfg = CFG[size];
+  const { theme } = useTheme();
+  const resolvedVariant: BloodGroupBadgeVariant =
+    variant ?? ((inverted || showGlow) ? 'solid' : 'soft');
+  const cfg = SIZE_CFG[size];
+
+  let bg: string, fg: string, borderColor: string, borderWidth = 0;
+  switch (resolvedVariant) {
+    case 'solid':
+      bg = theme.primary; fg = theme.textOnPrimary; borderColor = 'transparent';
+      break;
+    case 'outline':
+      bg = 'transparent'; fg = theme.primary; borderColor = theme.primary; borderWidth = 1.5;
+      break;
+    case 'ghost':
+      bg = 'transparent'; fg = theme.primary; borderColor = 'transparent';
+      break;
+    case 'soft':
+    default:
+      bg = theme.primarySoft; fg = theme.primary; borderColor = 'transparent';
+  }
 
   return (
-    <View style={[
-      styles.base,
-      {
-        width: cfg.w,
-        height: cfg.h,
-        borderRadius: cfg.br,
-        backgroundColor: solid ? color : `${color}1A`,
-        borderColor: color,
-        borderWidth: solid ? 0 : 1.5,
-      },
-      style,
-    ]}>
-      <Text style={[
-        styles.text,
-        { fontSize: cfg.fs, color: solid ? '#fff' : color },
-      ]}>
-        {bloodGroup}
-      </Text>
+    <View
+      accessibilityRole="text"
+      accessibilityLabel={`Blood group ${bloodGroup}`}
+      style={[
+        styles.base,
+        {
+          paddingHorizontal: cfg.px, paddingVertical: cfg.py,
+          minWidth: cfg.minW,
+          backgroundColor: bg, borderColor, borderWidth,
+        },
+        style,
+      ]}
+    >
+      <Text style={[styles.text, { fontSize: cfg.fs, color: fg }]}>{bloodGroup}</Text>
     </View>
   );
 });
 
 const styles = StyleSheet.create({
-  base: { alignItems: 'center', justifyContent: 'center' },
-  text: { fontWeight: FontWeight.black, letterSpacing: -0.3 },
+  base: { alignItems: 'center', justifyContent: 'center', borderRadius: Radius.pill },
+  text: { fontWeight: FontWeight.black, letterSpacing: LetterSpacing.tight },
 });
 
 export default BloodGroupBadge;

--- a/mobile/components/Card.tsx
+++ b/mobile/components/Card.tsx
@@ -1,35 +1,72 @@
 // components/Card.tsx
-import React from 'react';
-import { View, StyleSheet, ViewStyle, StyleProp } from 'react-native';
-import { useTheme } from '@/contexts/ThemeContext';
-import { Radius, Spacing } from '@/constants/Typography';
+// Variants: surface (default) | elevated | ghost | tinted
+// Generic theme-tokenized surface with optional press feedback.
 
-interface CardProps {
+import React from 'react';
+import {
+  View, Pressable, StyleSheet, ViewStyle, StyleProp,
+} from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+import { Radius, Spacing, Elevation } from '@/constants/Typography';
+
+export type CardVariant = 'surface' | 'elevated' | 'ghost' | 'tinted';
+
+export interface CardProps {
   children: React.ReactNode;
+  variant?: CardVariant;
+  radius?: number;
   style?: StyleProp<ViewStyle>;
   noPadding?: boolean;
+  /** Backwards-compat — `elevated` flag maps to variant='elevated'. */
   elevated?: boolean;
+  onPress?: () => void;
+  accessibilityLabel?: string;
 }
 
-const Card = React.memo(function Card({ children, style, noPadding, elevated }: CardProps) {
+const Card = React.memo(function Card({
+  children, variant, radius = Radius.lg, style, noPadding, elevated, onPress, accessibilityLabel,
+}: CardProps) {
   const { theme } = useTheme();
-  return (
-    <View style={[
-      styles.card,
-      {
-        backgroundColor: elevated ? theme.cardElevated : theme.card,
-        borderColor: theme.border,
-      },
-      noPadding ? null : styles.padding,
-      style,
-    ]}>
-      {children}
-    </View>
-  );
+  const v: CardVariant = variant ?? (elevated ? 'elevated' : 'surface');
+
+  const bg =
+    v === 'elevated' ? theme.cardElevated
+    : v === 'tinted' ? theme.primarySoft
+    : v === 'ghost'  ? 'transparent'
+    :                  theme.card;
+
+  const borderColor = v === 'ghost' ? 'transparent' : theme.border;
+
+  const baseStyle: ViewStyle[] = [
+    styles.card,
+    {
+      borderRadius: radius,
+      backgroundColor: bg,
+      borderColor,
+      borderWidth: v === 'ghost' ? 0 : StyleSheet.hairlineWidth,
+    },
+    v === 'elevated' && Elevation.base,
+    noPadding ? undefined : styles.padding,
+  ].filter(Boolean) as ViewStyle[];
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        style={({ pressed }) => [...baseStyle, pressed && { opacity: 0.92 }, style as ViewStyle]}
+      >
+        {children}
+      </Pressable>
+    );
+  }
+
+  return <View style={[...baseStyle, style as ViewStyle]}>{children}</View>;
 });
 
 const styles = StyleSheet.create({
-  card:    { borderRadius: Radius.md, borderWidth: StyleSheet.hairlineWidth },
+  card:    {},
   padding: { padding: Spacing[4] },
 });
 

--- a/mobile/components/CustomAlert.tsx
+++ b/mobile/components/CustomAlert.tsx
@@ -70,6 +70,12 @@ const CustomAlert = React.memo(function CustomAlert({
                         transform: [{ scale: scaleAnim }],
                     },
                 ]}>
+                    {/* Brand accent strip + handle — Request-screen sheet parity */}
+                    <View style={styles.sheetTop}>
+                        <View style={[styles.accentStrip, { backgroundColor: theme.primary }]} />
+                        <View style={[styles.handle, { backgroundColor: theme.borderStrong }]} />
+                    </View>
+
                     {/* Icon */}
                     {icon && <Text style={styles.icon}>{icon}</Text>}
 
@@ -148,6 +154,9 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         paddingTop: Spacing[6],
     },
+    sheetTop:    { alignItems: 'center', paddingTop: Spacing[3], paddingBottom: Spacing[2] },
+    accentStrip: { width: 36, height: 3, borderRadius: 2, marginBottom: Spacing[1], opacity: 0.9 },
+    handle:      { width: 44, height: 4, borderRadius: 2 },
     icon: { fontSize: 40, marginBottom: Spacing[3] },
     title: {
         fontSize: FontSize.lg,

--- a/mobile/components/LoadingScreen.tsx
+++ b/mobile/components/LoadingScreen.tsx
@@ -1,11 +1,11 @@
 // components/LoadingScreen.tsx
-// Boot / route-loading state. Uses shimmer skeleton (not ActivityIndicator)
-// per project's loading-pattern rule.
+// Boot / route-loading state. Shimmer skeleton + vector brand mark.
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '@/contexts/ThemeContext';
 import { FontSize, FontWeight, Spacing, LetterSpacing, Radius } from '@/constants/Typography';
+import BrandMark from './BrandMark';
 import Skeleton from './Skeleton';
 
 interface LoadingScreenProps {
@@ -17,7 +17,7 @@ const LoadingScreen = React.memo(function LoadingScreen({ message }: LoadingScre
   const insets    = useSafeAreaInsets();
   return (
     <View style={[styles.root, { backgroundColor: theme.background, paddingBottom: insets.bottom }]}>
-      <Text style={[styles.wordmark, { color: theme.primary }]}>🩸</Text>
+      <BrandMark size={48} />
       <Text style={[styles.brand, { color: theme.textPrimary }]}>BLUDSTACK</Text>
       <View style={styles.skeletonRow}>
         <Skeleton width={140} height={4} radius={Radius.full} />
@@ -29,7 +29,6 @@ const LoadingScreen = React.memo(function LoadingScreen({ message }: LoadingScre
 
 const styles = StyleSheet.create({
   root:        { flex: 1, alignItems: 'center', justifyContent: 'center', gap: Spacing[3] },
-  wordmark:    { fontSize: 52 },
   brand:       { fontSize: FontSize.sm, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.widest },
   skeletonRow: { marginTop: Spacing[5], alignItems: 'center' },
   msg:         { fontSize: FontSize.xs, marginTop: Spacing[2] },

--- a/mobile/components/ProfileCard.tsx
+++ b/mobile/components/ProfileCard.tsx
@@ -1,92 +1,119 @@
 // components/ProfileCard.tsx
+// Pill-radius profile card with avatar, status, blood badge, optional contact
+// row (Call / WhatsApp / Message). Used by the recipient to see an accepted
+// donor (and vice-versa). Contact rows only render when handlers are passed —
+// the parent controls disclosure (e.g. show only after donor accepts).
+
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import {
+  View, Text, StyleSheet, Pressable, Linking,
+} from 'react-native';
 import { Image } from 'expo-image';
+import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@/contexts/ThemeContext';
 import BloodGroupBadge from './BloodGroupBadge';
-import { FontSize, FontWeight, Spacing, Radius, LetterSpacing } from '@/constants/Typography';
-import { formatDate, canDonateAgain } from '@/utils/helpers';
+import {
+  FontSize, FontWeight, Spacing, Radius, LetterSpacing, Elevation,
+} from '@/constants/Typography';
+import { canDonateAgain } from '@/utils/helpers';
 
-interface ProfileCardProps {
-  profile: {
-    id: string;
-    full_name: string;
-    blood_group: string;
-    total_donations: number;
-    last_donation_date: string | null;
-    is_verified: boolean;
-    is_available_to_donate: boolean;
-    avatar_url: string | null;
-    medical_conditions?: string[];
-    share_medical_history?: boolean;
-  };
+export interface ProfileCardProfile {
+  id: string;
+  full_name: string;
+  blood_group: string;
+  total_donations: number;
+  last_donation_date: string | null;
+  is_verified: boolean;
+  is_available_to_donate: boolean;
+  avatar_url: string | null;
+  phone?: string | null;
+  whatsapp_available?: boolean;
+  medical_conditions?: string[];
+  share_medical_history?: boolean;
+}
+
+export interface ProfileCardProps {
+  profile: ProfileCardProfile;
   compact?: boolean;
   onPress?: () => void;
   onCall?: () => void;
   onMessage?: () => void;
+  onWhatsApp?: () => void;
 }
 
 const ProfileCard = React.memo(function ProfileCard({
-  profile, compact, onPress, onCall, onMessage,
+  profile, compact, onPress, onCall, onMessage, onWhatsApp,
 }: ProfileCardProps) {
   const { theme } = useTheme();
   const { canDonate, daysLeft } = canDonateAgain(profile.last_donation_date);
-  const available = profile.is_available_to_donate && canDonate;
+  const available   = profile.is_available_to_donate && canDonate;
   const statusColor = available ? theme.success : theme.warning;
+  const statusLabel = available
+    ? 'Available'
+    : daysLeft > 0
+      ? `Cooldown · ${daysLeft}d`
+      : 'Unavailable';
 
-  return (
-    <TouchableOpacity
-      onPress={onPress}
-      activeOpacity={onPress ? 0.7 : 1}
-      disabled={!onPress}
-      style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}
-    >
+  // Default fallback handlers when parent passes the contact intent
+  const handleCall = () => {
+    if (onCall) onCall();
+    else if (profile.phone) Linking.openURL(`tel:${profile.phone}`);
+  };
+  const handleWhatsApp = () => {
+    if (onWhatsApp) onWhatsApp();
+    else if (profile.phone) {
+      const digits = profile.phone.replace(/\D/g, '');
+      Linking.openURL(`https://wa.me/${digits}`);
+    }
+  };
+
+  const Body = (
+    <View>
       <View style={styles.header}>
-        {/* Avatar */}
         <View style={[styles.avatarWrap, { borderColor: statusColor }]}>
           {profile.avatar_url ? (
             <Image source={{ uri: profile.avatar_url }} style={styles.avatar} contentFit="cover" />
           ) : (
             <View style={[styles.avatarFallback, { backgroundColor: theme.cardElevated }]}>
               <Text style={[styles.initial, { color: theme.textPrimary }]}>
-                {profile.full_name.charAt(0).toUpperCase()}
+                {profile.full_name?.charAt(0)?.toUpperCase() ?? '?'}
               </Text>
             </View>
           )}
-          <View style={[styles.statusDot, { backgroundColor: statusColor, borderColor: theme.card }]} />
+          <View
+            style={[
+              styles.statusDot,
+              { backgroundColor: statusColor, borderColor: theme.card },
+            ]}
+          />
         </View>
 
-        {/* Info */}
         <View style={styles.info}>
           <View style={styles.nameRow}>
             <Text style={[styles.name, { color: theme.textPrimary }]} numberOfLines={1}>
               {profile.full_name}
             </Text>
             {profile.is_verified && (
-              <Text style={[styles.verified, { color: theme.success }]}> ✓</Text>
+              <Ionicons name="checkmark-circle" size={16} color={theme.success} style={{ marginLeft: 4 }} />
             )}
           </View>
-          <Text style={[styles.status, { color: statusColor }]}>
-            {available ? 'Available to donate' : daysLeft > 0 ? `Eligible in ${daysLeft} days` : 'Unavailable'}
-          </Text>
+          <Text style={[styles.status, { color: statusColor }]}>{statusLabel}</Text>
           {!compact && (
             <Text style={[styles.meta, { color: theme.textMuted }]}>
               {profile.total_donations} donation{profile.total_donations !== 1 ? 's' : ''}
-              {profile.last_donation_date ? `  ·  Last: ${formatDate(profile.last_donation_date)}` : ''}
             </Text>
           )}
         </View>
 
-        <BloodGroupBadge bloodGroup={profile.blood_group} size={compact ? 'sm' : 'md'} />
+        <BloodGroupBadge bloodGroup={profile.blood_group} size={compact ? 'sm' : 'md'} variant="soft" />
       </View>
 
-      {/* Medical conditions */}
       {!compact && profile.share_medical_history && (profile.medical_conditions?.length ?? 0) > 0 && (
-        <View style={[styles.medRow, { borderTopColor: theme.border }]}>
-          <Text style={[styles.medTitle, { color: theme.textMuted }]}>DISCLOSED CONDITIONS</Text>
+        <View style={[styles.medRow, { borderTopColor: theme.divider }]}>
+          <Text style={[styles.medTitle, { color: theme.textMuted }]}>Disclosed conditions</Text>
           <View style={styles.tags}>
             {profile.medical_conditions!.map(c => (
-              <View key={c} style={[styles.tag, { backgroundColor: theme.cardElevated }]}>
+              <View key={c} style={[styles.tag, { backgroundColor: theme.cardElevated, borderColor: theme.border }]}>
                 <Text style={[styles.tagText, { color: theme.textSecondary }]}>{c}</Text>
               </View>
             ))}
@@ -94,47 +121,149 @@ const ProfileCard = React.memo(function ProfileCard({
         </View>
       )}
 
-      {/* Actions */}
-      {(onCall || onMessage) && (
-        <View style={[styles.actions, { borderTopColor: theme.border }]}>
-          {onMessage && (
-            <TouchableOpacity onPress={onMessage} style={[styles.actionBtn, { backgroundColor: theme.cardElevated }]} activeOpacity={0.7}>
-              <Text style={[styles.actionLabel, { color: theme.textPrimary }]}>💬  Message</Text>
-            </TouchableOpacity>
+      {/* Contact pill row — only shows when at least one handler is passed
+          AND we have a phone (for call/whatsapp) or onMessage. The recipient
+          gets these unmasked once the donor accepts (parent decides). */}
+      {(onCall || onMessage || onWhatsApp || profile.phone) && (
+        <View style={[styles.actions, { borderTopColor: theme.divider }]}>
+          {(onCall || profile.phone) && (
+            <Pressable
+              onPress={handleCall}
+              style={({ pressed }) => [
+                styles.actionPill,
+                { backgroundColor: theme.primary, opacity: pressed ? 0.9 : 1 },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`Call ${profile.full_name}`}
+            >
+              <Ionicons name="call" size={16} color={theme.textOnPrimary} />
+              <Text style={[styles.actionLabel, { color: theme.textOnPrimary }]}>Call</Text>
+            </Pressable>
           )}
-          {onCall && (
-            <TouchableOpacity onPress={onCall} style={[styles.actionBtn, { backgroundColor: theme.primary }]} activeOpacity={0.7}>
-              <Text style={[styles.actionLabel, { color: '#fff' }]}>📞  Call</Text>
-            </TouchableOpacity>
+          {(onWhatsApp || (profile.phone && profile.whatsapp_available)) && (
+            <Pressable
+              onPress={handleWhatsApp}
+              style={({ pressed }) => [
+                styles.actionPill,
+                { backgroundColor: theme.success, opacity: pressed ? 0.9 : 1 },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`WhatsApp ${profile.full_name}`}
+            >
+              <Ionicons name="logo-whatsapp" size={16} color={theme.textOnPrimary} />
+              <Text style={[styles.actionLabel, { color: theme.textOnPrimary }]}>WhatsApp</Text>
+            </Pressable>
+          )}
+          {onMessage && (
+            <Pressable
+              onPress={onMessage}
+              style={({ pressed }) => [
+                styles.actionPill,
+                { backgroundColor: theme.cardElevated, borderWidth: StyleSheet.hairlineWidth, borderColor: theme.border, opacity: pressed ? 0.9 : 1 },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`Message ${profile.full_name}`}
+            >
+              <Ionicons name="chatbubble-ellipses-outline" size={16} color={theme.textPrimary} />
+              <Text style={[styles.actionLabel, { color: theme.textPrimary }]}>Chat</Text>
+            </Pressable>
           )}
         </View>
       )}
-    </TouchableOpacity>
+    </View>
+  );
+
+  return onPress ? (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.card,
+        { backgroundColor: theme.card, borderColor: theme.border, opacity: pressed ? 0.95 : 1 },
+        Elevation.xs,
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${profile.full_name}`}
+    >
+      {Body}
+    </Pressable>
+  ) : (
+    <View
+      style={[
+        styles.card,
+        { backgroundColor: theme.card, borderColor: theme.border },
+        Elevation.xs,
+      ]}
+    >
+      {Body}
+    </View>
   );
 });
 
 const styles = StyleSheet.create({
-  card:         { borderRadius: Radius.md, borderWidth: StyleSheet.hairlineWidth, overflow: 'hidden', marginBottom: Spacing[3] },
-  header:       { flexDirection: 'row', alignItems: 'center', gap: Spacing[3], padding: Spacing[4] },
-  avatarWrap:   { borderRadius: Radius.full, borderWidth: 2, padding: 2 },
-  avatar:       { width: 50, height: 50, borderRadius: 25 },
-  avatarFallback:{ width: 50, height: 50, borderRadius: 25, alignItems: 'center', justifyContent: 'center' },
-  initial:      { fontSize: FontSize.lg, fontWeight: FontWeight.black },
-  statusDot:    { position: 'absolute', bottom: 0, right: 0, width: 12, height: 12, borderRadius: 6, borderWidth: 2 },
-  info:         { flex: 1, gap: 2 },
-  nameRow:      { flexDirection: 'row', alignItems: 'center' },
-  name:         { fontSize: FontSize.base, fontWeight: FontWeight.bold, flex: 1 },
-  verified:     { fontSize: FontSize.sm, fontWeight: FontWeight.bold },
-  status:       { fontSize: FontSize.xs, fontWeight: FontWeight.semibold, textTransform: 'uppercase', letterSpacing: LetterSpacing.wide },
-  meta:         { fontSize: FontSize.xs },
-  medRow:       { borderTopWidth: StyleSheet.hairlineWidth, padding: Spacing[4], paddingTop: Spacing[3], gap: Spacing[2] },
-  medTitle:     { fontSize: FontSize['2xs'], fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.widest, textTransform: 'uppercase' },
-  tags:         { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing[1] },
-  tag:          { paddingHorizontal: Spacing[2], paddingVertical: 3, borderRadius: Radius.xs },
-  tagText:      { fontSize: FontSize.xs },
-  actions:      { flexDirection: 'row', gap: Spacing[2], borderTopWidth: StyleSheet.hairlineWidth, padding: Spacing[3] },
-  actionBtn:    { flex: 1, paddingVertical: Spacing[3], borderRadius: Radius.xs, alignItems: 'center' },
-  actionLabel:  { fontSize: FontSize.sm, fontWeight: FontWeight.bold },
+  card: {
+    borderRadius: Radius.xl,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+    marginBottom: Spacing[3],
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing[3],
+    padding: Spacing[4],
+  },
+  avatarWrap: { borderRadius: Radius.pill, borderWidth: 2, padding: 2 },
+  avatar: { width: 50, height: 50, borderRadius: 25 },
+  avatarFallback: {
+    width: 50, height: 50, borderRadius: 25,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  initial: { fontSize: FontSize.lg, fontWeight: FontWeight.black },
+  statusDot: {
+    position: 'absolute', bottom: 0, right: 0,
+    width: 12, height: 12, borderRadius: 6, borderWidth: 2,
+  },
+  info: { flex: 1, gap: 2 },
+  nameRow: { flexDirection: 'row', alignItems: 'center' },
+  name: {
+    fontSize: FontSize.base, fontWeight: FontWeight.bold,
+    flexShrink: 1, letterSpacing: LetterSpacing.snug,
+  },
+  status: {
+    fontSize: FontSize.xs, fontWeight: FontWeight.bold,
+    letterSpacing: LetterSpacing.wide, textTransform: 'uppercase',
+  },
+  meta: { fontSize: FontSize.xs },
+  medRow: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: Spacing[4], paddingVertical: Spacing[3],
+    gap: Spacing[2],
+  },
+  medTitle: {
+    fontSize: FontSize['2xs'], fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest, textTransform: 'uppercase',
+  },
+  tags: { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing[1] },
+  tag: {
+    paddingHorizontal: Spacing[2], paddingVertical: 3,
+    borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
+  },
+  tagText: { fontSize: FontSize.xs },
+  actions: {
+    flexDirection: 'row', gap: Spacing[2],
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: Spacing[3], paddingVertical: Spacing[3],
+  },
+  actionPill: {
+    flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center',
+    gap: Spacing[1],
+    paddingVertical: Spacing[3],
+    borderRadius: Radius.pill,
+  },
+  actionLabel: {
+    fontSize: FontSize.sm, fontWeight: FontWeight.bold,
+    letterSpacing: LetterSpacing.snug,
+  },
 });
 
 export default ProfileCard;

--- a/mobile/components/RequestCard.tsx
+++ b/mobile/components/RequestCard.tsx
@@ -1,15 +1,21 @@
 // components/RequestCard.tsx
+// Pill-radius card for blood request listings. Theme-tokenised throughout.
+// Urgency stripe along the top, blood badge + hospital block, meta footer.
+// Optional inline accept/decline actions (donor side) — guarded by showActions.
+
 import React, { useCallback } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@/contexts/ThemeContext';
 import { BloodRequest } from '@/hooks/useRequests';
 import BloodGroupBadge from './BloodGroupBadge';
-import { FontSize, FontWeight, Spacing, Radius, LetterSpacing } from '@/constants/Typography';
-import { URGENCY_CONFIG } from '@/constants/BloodData';
+import {
+  FontSize, FontWeight, Spacing, Radius, LetterSpacing, Elevation,
+} from '@/constants/Typography';
 import { timeAgo, formatDistance } from '@/utils/helpers';
 import { haversineDistance } from '@/utils/geo';
 
-interface RequestCardProps {
+export interface RequestCardProps {
   request: BloodRequest;
   userLat?: number | null;
   userLon?: number | null;
@@ -19,16 +25,57 @@ interface RequestCardProps {
   showActions?: boolean;
 }
 
-const URGENCY_COLORS = { critical: '#E8002D', urgent: '#F5A623', standard: '#00A651' };
+const URGENCY_META: Record<string, { label: string; iconName: keyof typeof Ionicons.glyphMap; toneKey: 'danger' | 'warning' | 'success' }> = {
+  critical: { label: 'Critical', iconName: 'flash',           toneKey: 'danger'  },
+  urgent:   { label: 'Urgent',   iconName: 'time',            toneKey: 'warning' },
+  standard: { label: 'Standard', iconName: 'calendar-outline', toneKey: 'success' },
+};
 
 const RequestCard = React.memo(function RequestCard({
   request, userLat, userLon, onPress, onAccept, onDecline, showActions,
 }: RequestCardProps) {
   const { theme } = useTheme();
-  const urgency = URGENCY_CONFIG[request.urgency];
-  const urgencyColor = URGENCY_COLORS[request.urgency];
+  const meta = URGENCY_META[request.urgency] ?? URGENCY_META.urgent;
 
-  const distance = userLat && userLon
+  // Card colorway depends on status:
+  //   • active    → urgency tone (red/amber/green by criticality)
+  //   • fulfilled → SUCCESS green — the donation actually happened, this is
+  //                 a positive outcome, not a closure to mute.
+  //   • cancelled → monochrome muted grey (recipient walked away)
+  //   • expired   → monochrome muted grey (timed out without a donor)
+  const isDead      = request.status === 'cancelled' || request.status === 'expired';
+  const isFulfilled = request.status === 'fulfilled';
+
+  const toneColor = isDead
+    ? theme.textMuted
+    : isFulfilled
+      ? theme.success
+      : meta.toneKey === 'danger'  ? theme.danger
+      : meta.toneKey === 'warning' ? theme.warning
+      :                              theme.success;
+
+  const toneSoft  = isDead
+    ? theme.cardElevated
+    : isFulfilled
+      ? theme.successSoft
+      : meta.toneKey === 'danger'  ? theme.dangerSoft
+      : meta.toneKey === 'warning' ? theme.warningSoft
+      :                              theme.successSoft;
+
+  // Pill label + icon mirror the status when it's a terminal state, the
+  // urgency tier while the request is still live.
+  const pillIcon: keyof typeof Ionicons.glyphMap =
+    request.status === 'cancelled' ? 'close-circle'
+    : request.status === 'expired' ? 'time-outline'
+    : isFulfilled                  ? 'checkmark-circle'
+    : meta.iconName;
+  const pillLabel =
+    request.status === 'cancelled' ? 'Cancelled'
+    : request.status === 'expired' ? 'Expired'
+    : isFulfilled                  ? 'Fulfilled · life saved'
+    : meta.label;
+
+  const distance = (userLat != null && userLon != null)
     ? haversineDistance(userLat, userLon, request.latitude, request.longitude)
     : null;
 
@@ -37,42 +84,66 @@ const RequestCard = React.memo(function RequestCard({
   const handleDecline = useCallback(() => onDecline?.(request), [onDecline, request]);
 
   return (
-    <TouchableOpacity
+    <Pressable
       onPress={handlePress}
-      activeOpacity={onPress ? 0.7 : 1}
       disabled={!onPress}
-      style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}
+      style={({ pressed }) => [
+        styles.card,
+        {
+          backgroundColor: theme.card,
+          borderColor: theme.border,
+          // Dead requests fade slightly so they read as closed at a glance
+          // without losing legibility.
+          opacity: isDead ? 0.78 : (onPress && pressed ? 0.96 : 1),
+        },
+        Elevation.xs,
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={`Request for ${request.blood_group} at ${request.hospital_name}`}
     >
-      {/* Urgency indicator bar */}
-      <View style={[styles.urgencyBar, { backgroundColor: urgencyColor }]} />
+      {/* Urgency / status stripe */}
+      <View style={[styles.stripe, { backgroundColor: toneColor }]} />
 
       <View style={styles.inner}>
-        {/* Top: blood group + hospital */}
+        {/* Top row */}
         <View style={styles.topRow}>
-          <BloodGroupBadge bloodGroup={request.blood_group} size="lg" inverted />
+          <BloodGroupBadge
+            bloodGroup={request.blood_group}
+            // Solid for live + fulfilled (positive states), soft for dead.
+            size="lg"
+            variant={isDead ? 'soft' : 'solid'}
+          />
           <View style={styles.topRight}>
-            <Text style={[styles.hospital, { color: theme.textPrimary }]} numberOfLines={1}>
+            <Text
+              style={[
+                styles.hospital,
+                { color: isDead ? theme.textMuted : theme.textPrimary },
+              ]}
+              numberOfLines={1}
+            >
               {request.hospital_name}
             </Text>
-            <Text style={[styles.address, { color: theme.textSecondary }]} numberOfLines={1}>
+            <Text style={[styles.address, { color: theme.textMuted }]} numberOfLines={1}>
               {request.hospital_address}
             </Text>
-            {/* Urgency pill */}
-            <View style={[styles.urgencyPill, { backgroundColor: `${urgencyColor}18` }]}>
-              <Text style={[styles.urgencyText, { color: urgencyColor }]}>
-                {urgency.icon} {urgency.label}
-              </Text>
+            <View style={[styles.urgencyPill, { backgroundColor: toneSoft, borderColor: toneColor }]}>
+              <Ionicons name={pillIcon} size={12} color={toneColor} />
+              <Text style={[styles.urgencyText, { color: toneColor }]}>{pillLabel}</Text>
             </View>
           </View>
         </View>
 
         {/* Meta row */}
-        <View style={[styles.metaRow, { borderTopColor: theme.border }]}>
-          <MetaItem label="Units"    value={`${request.units_needed}`} theme={theme} />
+        <View style={[styles.metaRow, { borderTopColor: theme.divider }]}>
+          <MetaItem
+            label={request.units_needed === 1 ? 'Donor' : 'Donors'}
+            value={`${request.units_needed}`}
+            theme={theme}
+          />
           {distance !== null && (
             <MetaItem label="Distance" value={formatDistance(distance)} theme={theme} highlight />
           )}
-          <MetaItem label="Posted"   value={timeAgo(request.created_at)} theme={theme} />
+          <MetaItem label="Posted" value={timeAgo(request.created_at)} theme={theme} />
           <MetaItem
             label="Status"
             value={request.status}
@@ -81,43 +152,62 @@ const RequestCard = React.memo(function RequestCard({
           />
         </View>
 
-        {/* Notes */}
         {request.notes && (
-          <Text style={[styles.notes, { color: theme.textMuted, borderTopColor: theme.border }]} numberOfLines={2}>
+          <Text
+            style={[styles.notes, { color: theme.textMuted, borderTopColor: theme.divider }]}
+            numberOfLines={2}
+          >
             {request.notes}
           </Text>
         )}
 
-        {/* Actions */}
         {showActions && request.status === 'active' && (
-          <View style={[styles.actions, { borderTopColor: theme.border }]}>
-            <TouchableOpacity
+          <View style={[styles.actions, { borderTopColor: theme.divider }]}>
+            <Pressable
               onPress={handleDecline}
-              style={[styles.declineBtn, { borderColor: theme.border }]}
-              activeOpacity={0.7}
+              style={({ pressed }) => [
+                styles.declineBtn,
+                {
+                  borderColor: theme.border,
+                  backgroundColor: theme.cardElevated,
+                  opacity: pressed ? 0.9 : 1,
+                },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Decline"
             >
-              <Text style={[styles.declineLabel, { color: theme.textSecondary }]}>Decline</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
+              <Text style={[styles.declineLabel, { color: theme.textSecondary }]}>Not now</Text>
+            </Pressable>
+            <Pressable
               onPress={handleAccept}
-              style={[styles.acceptBtn, { backgroundColor: theme.primary }]}
-              activeOpacity={0.7}
+              style={({ pressed }) => [
+                styles.acceptBtn,
+                { backgroundColor: theme.primary, opacity: pressed ? 0.92 : 1 },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Accept and donate"
             >
-              <Text style={styles.acceptLabel}>🩸 Accept & Donate</Text>
-            </TouchableOpacity>
+              <Ionicons name="checkmark-circle" size={16} color={theme.textOnPrimary} />
+              <Text style={[styles.acceptLabel, { color: theme.textOnPrimary }]}>
+                Accept and donate
+              </Text>
+            </Pressable>
           </View>
         )}
       </View>
-    </TouchableOpacity>
+    </Pressable>
   );
 });
 
-function MetaItem({ label, value, theme, highlight, color }: {
-  label: string; value: string; theme: any; highlight?: boolean; color?: string;
-}) {
+function MetaItem({
+  label, value, theme, highlight, color,
+}: { label: string; value: string; theme: any; highlight?: boolean; color?: string }) {
   return (
     <View style={styles.metaItem}>
-      <Text style={[styles.metaValue, { color: color ?? (highlight ? theme.primary : theme.textPrimary) }]}>
+      <Text style={[
+        styles.metaValue,
+        { color: color ?? (highlight ? theme.primary : theme.textPrimary) },
+      ]} numberOfLines={1}>
         {value}
       </Text>
       <Text style={[styles.metaLabel, { color: theme.textMuted }]}>{label}</Text>
@@ -126,37 +216,70 @@ function MetaItem({ label, value, theme, highlight, color }: {
 }
 
 const styles = StyleSheet.create({
-  card:        { borderRadius: Radius.md, borderWidth: StyleSheet.hairlineWidth, overflow: 'hidden', marginBottom: Spacing[3] },
-  urgencyBar:  { height: 3 },
-  inner:       { padding: Spacing[4], gap: Spacing[3] },
-  topRow:      { flexDirection: 'row', gap: Spacing[3] },
-  topRight:    { flex: 1, gap: Spacing[1] },
-  hospital:    { fontSize: FontSize.base, fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.snug },
-  address:     { fontSize: FontSize.sm, fontWeight: FontWeight.regular },
-  urgencyPill: { alignSelf: 'flex-start', paddingHorizontal: Spacing[2], paddingVertical: 2, borderRadius: Radius.xs, marginTop: Spacing[1] },
-  urgencyText: { fontSize: FontSize.xs, fontWeight: FontWeight.bold },
+  card: {
+    borderRadius: Radius.xl,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+    marginBottom: Spacing[3],
+  },
+  stripe: { height: 4 },
+  inner:  { padding: Spacing[4], gap: Spacing[3] },
+  topRow: { flexDirection: 'row', alignItems: 'center', gap: Spacing[3] },
+  topRight: { flex: 1, gap: Spacing[1] },
+  hospital: {
+    fontSize: FontSize.base, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.snug,
+  },
+  address: { fontSize: FontSize.sm },
+  urgencyPill: {
+    flexDirection: 'row', alignItems: 'center', gap: 4,
+    alignSelf: 'flex-start',
+    paddingHorizontal: Spacing[2], paddingVertical: 3,
+    borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
+    marginTop: Spacing[1],
+  },
+  urgencyText: {
+    fontSize: FontSize['2xs'], fontWeight: FontWeight.black,
+    letterSpacing: LetterSpacing.widest, textTransform: 'uppercase',
+  },
   metaRow: {
     flexDirection: 'row', justifyContent: 'space-between',
-    borderTopWidth: StyleSheet.hairlineWidth, paddingTop: Spacing[3],
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingTop: Spacing[3],
   },
   metaItem:  { alignItems: 'center', flex: 1 },
-  metaValue: { fontSize: FontSize.sm, fontWeight: FontWeight.bold },
-  metaLabel: { fontSize: FontSize.xs, marginTop: 2, textTransform: 'uppercase', letterSpacing: LetterSpacing.wide },
+  metaValue: {
+    fontSize: FontSize.sm, fontWeight: FontWeight.bold,
+    letterSpacing: LetterSpacing.snug,
+  },
+  metaLabel: {
+    fontSize: FontSize['2xs'], marginTop: 2,
+    textTransform: 'uppercase', letterSpacing: LetterSpacing.widest, fontWeight: FontWeight.bold,
+  },
   notes: {
     fontSize: FontSize.xs, fontStyle: 'italic',
     borderTopWidth: StyleSheet.hairlineWidth, paddingTop: Spacing[3],
+    lineHeight: FontSize.xs * 1.6,
   },
   actions: {
     flexDirection: 'row', gap: Spacing[2],
     borderTopWidth: StyleSheet.hairlineWidth, paddingTop: Spacing[3],
   },
   declineBtn: {
-    flex: 1, paddingVertical: Spacing[3], borderRadius: Radius.xs,
-    alignItems: 'center', borderWidth: 1,
+    flex: 1, paddingVertical: Spacing[3],
+    borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center', justifyContent: 'center',
   },
-  acceptBtn:   { flex: 2, paddingVertical: Spacing[3], borderRadius: Radius.xs, alignItems: 'center', backgroundColor: '#E8002D' },
-  declineLabel:{ fontSize: FontSize.sm, fontWeight: FontWeight.semibold },
-  acceptLabel: { fontSize: FontSize.sm, fontWeight: FontWeight.bold, color: '#fff' },
+  declineLabel: {
+    fontSize: FontSize.sm, fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.snug,
+  },
+  acceptBtn: {
+    flex: 2, paddingVertical: Spacing[3],
+    borderRadius: Radius.pill,
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: Spacing[1],
+  },
+  acceptLabel: {
+    fontSize: FontSize.sm, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.snug,
+  },
 });
 
 export default RequestCard;

--- a/mobile/components/ScreenHeader.tsx
+++ b/mobile/components/ScreenHeader.tsx
@@ -1,47 +1,72 @@
 // components/ScreenHeader.tsx
+// Variants: solid (default) | transparent | floating
+// Pill back button (Ionicons chevron), centered title block, right slot.
+
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@/contexts/ThemeContext';
-import { FontSize, FontWeight, Spacing, LetterSpacing } from '@/constants/Typography';
+import {
+  FontSize, FontWeight, Spacing, LetterSpacing, Radius,
+} from '@/constants/Typography';
 
-interface ScreenHeaderProps {
+export type ScreenHeaderVariant = 'solid' | 'transparent' | 'floating';
+
+export interface ScreenHeaderProps {
   title: string;
   subtitle?: string;
   showBack?: boolean;
+  onBack?: () => void;
   rightAction?: React.ReactNode;
+  variant?: ScreenHeaderVariant;
+  /** Backwards-compat for the `transparent` prop. */
   transparent?: boolean;
 }
 
 const ScreenHeader = React.memo(function ScreenHeader({
-  title, subtitle, showBack = false, rightAction, transparent = false,
+  title, subtitle, showBack = false, onBack, rightAction, variant, transparent,
 }: ScreenHeaderProps) {
   const { theme } = useTheme();
   const router    = useRouter();
   const insets    = useSafeAreaInsets();
+  const v: ScreenHeaderVariant = variant ?? (transparent ? 'transparent' : 'solid');
+
+  const bg =
+    v === 'solid' ? theme.surface
+    :               'transparent';
+
+  const border = v === 'solid' ? theme.border : 'transparent';
 
   return (
     <View style={[
       styles.wrap,
       {
-        paddingTop:      insets.top + Spacing[3],
-        backgroundColor: transparent ? 'transparent' : theme.surface,
-        borderBottomColor: transparent ? 'transparent' : theme.border,
-        borderBottomWidth: transparent ? 0 : StyleSheet.hairlineWidth,
+        paddingTop: insets.top + Spacing[2],
+        backgroundColor: bg,
+        borderBottomColor: border,
+        borderBottomWidth: v === 'solid' ? StyleSheet.hairlineWidth : 0,
       },
     ]}>
       <View style={styles.row}>
-        {/* Back button */}
         {showBack ? (
-          <TouchableOpacity onPress={() => router.back()} style={styles.backBtn} activeOpacity={0.6}>
-            <Text style={[styles.backArrow, { color: theme.textPrimary }]}>←</Text>
-          </TouchableOpacity>
+          <Pressable
+            onPress={onBack ?? (() => router.back())}
+            style={[
+              styles.iconBtn,
+              { backgroundColor: v === 'floating' ? theme.surface : 'transparent', borderColor: v === 'floating' ? theme.border : 'transparent' },
+            ]}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+          >
+            <Ionicons name="chevron-back" size={22} color={theme.textPrimary} />
+          </Pressable>
         ) : (
           <View style={styles.sideSlot} />
         )}
 
-        {/* Title block */}
         <View style={styles.titleBlock}>
           <Text style={[styles.title, { color: theme.textPrimary }]} numberOfLines={1}>
             {title}
@@ -53,10 +78,7 @@ const ScreenHeader = React.memo(function ScreenHeader({
           )}
         </View>
 
-        {/* Right action */}
-        <View style={styles.sideSlot}>
-          {rightAction}
-        </View>
+        <View style={styles.sideSlot}>{rightAction}</View>
       </View>
     </View>
   );
@@ -64,13 +86,18 @@ const ScreenHeader = React.memo(function ScreenHeader({
 
 const styles = StyleSheet.create({
   wrap:       { paddingBottom: Spacing[3] },
-  row:        { flexDirection: 'row', alignItems: 'center', paddingHorizontal: Spacing[5] },
-  backBtn:    { width: 40, height: 40, justifyContent: 'center' },
-  backArrow:  { fontSize: FontSize.xl, fontWeight: FontWeight.bold },
-  titleBlock: { flex: 1, alignItems: 'center' },
-  title:      { fontSize: FontSize.base, fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.snug },
-  subtitle:   { fontSize: FontSize.xs, marginTop: 1 },
-  sideSlot:   { width: 40, alignItems: 'flex-end' },
+  row:        { flexDirection: 'row', alignItems: 'center', paddingHorizontal: Spacing[4] },
+  iconBtn: {
+    width: 40, height: 40, borderRadius: Radius.pill,
+    alignItems: 'center', justifyContent: 'center',
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  titleBlock: { flex: 1, alignItems: 'center', paddingHorizontal: Spacing[3] },
+  title: {
+    fontSize: FontSize.base, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.snug,
+  },
+  subtitle: { fontSize: FontSize.xs, marginTop: 2 },
+  sideSlot: { width: 40, alignItems: 'flex-end' },
 });
 
 export default ScreenHeader;

--- a/mobile/components/SelectSheet.tsx
+++ b/mobile/components/SelectSheet.tsx
@@ -1,77 +1,117 @@
 // components/SelectSheet.tsx
+// Bottom-sheet selector with backdrop + handle. Theme-tokenised, accepts a
+// `value` prop (new) OR `selected` (legacy) for the active option.
+
 import React, { useCallback } from 'react';
 import {
-  Modal, View, Text, TouchableOpacity, FlatList,
-  StyleSheet, TouchableWithoutFeedback,
+  Modal, View, Text, Pressable, FlatList, StyleSheet,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/contexts/ThemeContext';
-import { FontSize, FontWeight, Spacing, Radius, LetterSpacing } from '@/constants/Typography';
+import {
+  FontSize, FontWeight, Spacing, Radius, LetterSpacing, Elevation,
+} from '@/constants/Typography';
 
-interface Option<T = string> {
+export interface SelectSheetOption<T = string> {
   label: string;
   value: T;
-  icon?: string;
+  iconName?: keyof typeof Ionicons.glyphMap;
   description?: string;
+  /** Backwards-compat: legacy string icon (ignored visually). */
+  icon?: string;
 }
 
-interface SelectSheetProps<T = string> {
+export interface SelectSheetProps<T = string> {
   visible: boolean;
   title: string;
-  options: Option<T>[];
+  options: SelectSheetOption<T>[];
+  /** Preferred prop name. */
+  value?: T;
+  /** Backwards-compat. */
   selected?: T;
   onSelect: (value: T) => void;
   onClose: () => void;
 }
 
 function SelectSheet<T extends string>({
-  visible, title, options, selected, onSelect, onClose,
+  visible, title, options, value, selected, onSelect, onClose,
 }: SelectSheetProps<T>) {
   const { theme } = useTheme();
   const insets    = useSafeAreaInsets();
+  const active = value ?? selected;
 
-  const renderItem = useCallback(({ item }: { item: Option<T> }) => {
-    const isSelected = item.value === selected;
+  const renderItem = useCallback(({ item }: { item: SelectSheetOption<T> }) => {
+    const isSelected = item.value === active;
     return (
-      <TouchableOpacity
-        onPress={() => { onSelect(item.value); onClose(); }}
-        style={[styles.option, { borderBottomColor: theme.border }]}
-        activeOpacity={0.6}
+      <Pressable
+        onPress={() => { Haptics.selectionAsync().catch(() => {}); onSelect(item.value); onClose(); }}
+        style={({ pressed }) => [
+          styles.option,
+          { backgroundColor: pressed ? theme.cardHover : 'transparent' },
+        ]}
+        accessibilityRole="radio"
+        accessibilityState={{ selected: isSelected }}
       >
-        {item.icon && <Text style={styles.optIcon}>{item.icon}</Text>}
+        {item.iconName && (
+          <View style={[styles.iconWrap, { backgroundColor: theme.primarySoft }]}>
+            <Ionicons name={item.iconName} size={18} color={theme.primary} />
+          </View>
+        )}
         <View style={styles.optText}>
-          <Text style={[styles.optLabel, { color: isSelected ? theme.primary : theme.textPrimary }]}>
+          <Text style={[
+            styles.optLabel,
+            { color: isSelected ? theme.primary : theme.textPrimary },
+          ]}>
             {item.label}
           </Text>
           {item.description && (
             <Text style={[styles.optDesc, { color: theme.textMuted }]}>{item.description}</Text>
           )}
         </View>
-        {isSelected && (
-          <Text style={[styles.check, { color: theme.primary }]}>✓</Text>
-        )}
-      </TouchableOpacity>
+        <Ionicons
+          name={isSelected ? 'radio-button-on' : 'radio-button-off'}
+          size={22}
+          color={isSelected ? theme.primary : theme.textTertiary}
+        />
+      </Pressable>
     );
-  }, [selected, theme, onSelect, onClose]);
+  }, [active, theme, onSelect, onClose]);
 
   return (
-    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-      <TouchableWithoutFeedback onPress={onClose}>
-        <View style={styles.backdrop} />
-      </TouchableWithoutFeedback>
-      <View style={[styles.sheet, {
-        backgroundColor: theme.surface,
-        paddingBottom: insets.bottom + Spacing[4],
-      }]}>
-        <View style={[styles.handle, { backgroundColor: theme.border }]} />
-        <Text style={[styles.sheetTitle, { color: theme.textPrimary, borderBottomColor: theme.border }]}>
-          {title}
-        </Text>
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose} statusBarTranslucent>
+      <Pressable style={[styles.backdrop, { backgroundColor: theme.scrim }]} onPress={onClose} />
+      <View
+        style={[
+          styles.sheet,
+          {
+            backgroundColor: theme.surface,
+            borderColor: theme.border,
+            paddingBottom: insets.bottom + Spacing[3],
+          },
+          Elevation.lg,
+        ]}
+      >
+        {/* Brand accent strip + handle — matches Request screen sheet language. */}
+        <View style={styles.sheetTop}>
+          <View style={[styles.accentStrip, { backgroundColor: theme.primary }]} />
+          <View style={[styles.handle, { backgroundColor: theme.borderStrong }]} />
+        </View>
+        <View style={styles.sheetHeader}>
+          <Text style={[styles.sheetTitle, { color: theme.textPrimary }]}>{title}</Text>
+          <Pressable onPress={onClose} hitSlop={8} accessibilityLabel="Close">
+            <Ionicons name="close" size={22} color={theme.textMuted} />
+          </Pressable>
+        </View>
+        <View style={[styles.divider, { backgroundColor: theme.divider }]} />
         <FlatList
           data={options}
           keyExtractor={(item) => String(item.value)}
           renderItem={renderItem}
           showsVerticalScrollIndicator={false}
+          contentContainerStyle={{ paddingVertical: Spacing[2] }}
+          ItemSeparatorComponent={() => <View style={{ height: 2 }} />}
         />
       </View>
     </Modal>
@@ -79,30 +119,38 @@ function SelectSheet<T extends string>({
 }
 
 const styles = StyleSheet.create({
-  backdrop:   { flex: 1, backgroundColor: 'rgba(0,0,0,0.55)' },
+  backdrop: { ...StyleSheet.absoluteFillObject },
   sheet: {
+    position: 'absolute', left: 0, right: 0, bottom: 0,
     borderTopLeftRadius: Radius['2xl'],
     borderTopRightRadius: Radius['2xl'],
-    maxHeight: '75%',
+    maxHeight: '78%',
     paddingTop: Spacing[2],
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderLeftWidth: StyleSheet.hairlineWidth,
+    borderRightWidth: StyleSheet.hairlineWidth,
   },
-  handle: { width: 36, height: 4, borderRadius: 2, alignSelf: 'center', marginBottom: Spacing[3] },
-  sheetTitle: {
-    fontSize: FontSize.base, fontWeight: FontWeight.black,
-    letterSpacing: LetterSpacing.snug,
-    paddingHorizontal: Spacing[6], paddingBottom: Spacing[4],
-    borderBottomWidth: StyleSheet.hairlineWidth,
+  sheetTop:    { alignItems: 'center', paddingTop: Spacing[2], paddingBottom: Spacing[2] },
+  accentStrip: { width: 36, height: 3, borderRadius: 2, marginBottom: Spacing[1], opacity: 0.9 },
+  handle:      { width: 44, height: 4, borderRadius: 2 },
+  sheetHeader: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingHorizontal: Spacing[5], paddingVertical: Spacing[3],
   },
+  sheetTitle: { fontSize: FontSize.lg, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.tight },
+  divider:    { height: StyleSheet.hairlineWidth, marginHorizontal: Spacing[5] },
   option: {
     flexDirection: 'row', alignItems: 'center',
-    paddingHorizontal: Spacing[6], paddingVertical: Spacing[4],
-    borderBottomWidth: StyleSheet.hairlineWidth, gap: Spacing[3],
+    paddingHorizontal: Spacing[5], paddingVertical: Spacing[4],
+    gap: Spacing[3],
   },
-  optIcon:  { fontSize: 20 },
+  iconWrap: {
+    width: 36, height: 36, borderRadius: Radius.pill,
+    alignItems: 'center', justifyContent: 'center',
+  },
   optText:  { flex: 1 },
-  optLabel: { fontSize: FontSize.base, fontWeight: FontWeight.medium },
-  optDesc:  { fontSize: FontSize.xs, marginTop: 2 },
-  check:    { fontSize: FontSize.md, fontWeight: FontWeight.black },
+  optLabel: { fontSize: FontSize.base, fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.snug },
+  optDesc:  { fontSize: FontSize.xs, marginTop: 2, lineHeight: FontSize.xs * 1.5 },
 });
 
 export default SelectSheet;

--- a/mobile/components/StatsBanner.tsx
+++ b/mobile/components/StatsBanner.tsx
@@ -20,7 +20,8 @@ const StatsBanner = React.memo(function StatsBanner() {
         if (cancelled) return;
         const donations = data?.total_donations ?? data?.donations ?? 0;
         const donors    = data?.active_donors   ?? data?.donors    ?? 0;
-        const lives     = data?.lives_helped    ?? data?.lives     ?? donations * 3;
+        // 1 donor = 1 unit = 1 life. No 3x multiplier inflation.
+        const lives     = data?.lives_helped    ?? data?.lives     ?? donations;
         setStats({ donations, donors, lives });
       } catch {
         // Stats are non-critical — silently keep zeros
@@ -50,7 +51,7 @@ function Stat({ label, value, color, theme }: { label: string; value: number; co
 }
 
 const styles = StyleSheet.create({
-  row:       { flexDirection: 'row', borderWidth: StyleSheet.hairlineWidth, borderRadius: Radius.md, paddingVertical: Spacing[4] },
+  row:       { flexDirection: 'row', borderWidth: StyleSheet.hairlineWidth, borderRadius: Radius.xl, paddingVertical: Spacing[4] },
   sep:       { width: StyleSheet.hairlineWidth, marginVertical: Spacing[1] },
   stat:      { flex: 1, alignItems: 'center', gap: 2 },
   statNum:   { fontSize: FontSize.xl, fontWeight: FontWeight.black, letterSpacing: LetterSpacing.tight },

--- a/mobile/components/ToggleSwitch.tsx
+++ b/mobile/components/ToggleSwitch.tsx
@@ -1,26 +1,117 @@
 // components/ToggleSwitch.tsx
-import React from 'react';
-import { View, Text, Switch, StyleSheet } from 'react-native';
-import { useTheme } from '@/contexts/ThemeContext';
-import { FontSize, FontWeight, Spacing, LetterSpacing } from '@/constants/Typography';
+// ──────────────────────────────────────────────────────────────────────────────
+// Canonical 2026-style pill toggle for the entire app. NEVER use the native
+// `<Switch>` directly — design consistency across platforms is the whole point.
+// The thumb is animated on the UI thread via Reanimated v4 worklets.
+//
+// Two visual variants:
+//   • `card`    (default) — bordered surface card with full padding. Use this
+//                everywhere a toggle stands on its own (profile edit, onboarding
+//                share/availability toggles, settings rows on profile/edit).
+//   • `inline`  — flush row with no background. Use this inside an already-
+//                bordered container (e.g. (tabs)/profile section cards).
+//
+// Both variants share the same pill thumb so the visual identity is identical;
+// only the row chrome differs.
+// ──────────────────────────────────────────────────────────────────────────────
 
-interface ToggleSwitchProps {
+import React, { useEffect } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import Animated, {
+  useAnimatedStyle, useSharedValue, withSpring, withTiming, Easing,
+  interpolateColor,
+} from 'react-native-reanimated';
+import * as Haptics from 'expo-haptics';
+import { useTheme } from '@/contexts/ThemeContext';
+import {
+  FontSize, FontWeight, LetterSpacing, Radius, Spacing,
+} from '@/constants/Typography';
+
+export interface ToggleSwitchProps {
   label: string;
   description?: string;
   value: boolean;
   onValueChange: (v: boolean) => void;
+  iconName?: keyof typeof Ionicons.glyphMap;
+  /** Legacy string icon — ignored. */
   icon?: string;
   disabled?: boolean;
+  /** 'card' (default) is the standalone bordered row; 'inline' is flush. */
+  variant?: 'card' | 'inline';
 }
 
+// Track + thumb dimensions — single source of truth so every toggle looks
+// pixel-identical across screens.
+const TRACK_W   = 48;
+const TRACK_H   = 28;
+const THUMB     = 22;
+const THUMB_PAD = (TRACK_H - THUMB) / 2;     // 3
+const THUMB_MAX = TRACK_W - THUMB - THUMB_PAD * 2; // 20
+
 const ToggleSwitch = React.memo(function ToggleSwitch({
-  label, description, value, onValueChange, icon, disabled = false,
+  label, description, value, onValueChange,
+  iconName, disabled = false, variant = 'card',
 }: ToggleSwitchProps) {
   const { theme } = useTheme();
+
+  // Single animated progress 0→1 drives both thumb position and track color.
+  const progress = useSharedValue(value ? 1 : 0);
+  useEffect(() => {
+    progress.value = withSpring(value ? 1 : 0, {
+      damping: 18, stiffness: 240, mass: 0.5,
+    });
+  }, [value, progress]);
+
+  const thumbStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: THUMB_PAD + progress.value * THUMB_MAX },
+    ],
+  }));
+
+  const trackStyle = useAnimatedStyle(() => ({
+    backgroundColor: interpolateColor(
+      progress.value,
+      [0, 1],
+      [theme.cardElevated, theme.primary],
+    ),
+    borderColor: interpolateColor(
+      progress.value,
+      [0, 1],
+      [theme.border, theme.primary],
+    ),
+  }));
+
+  const onPress = () => {
+    if (disabled) return;
+    Haptics.selectionAsync().catch(() => {});
+    onValueChange(!value);
+  };
+
   return (
-    <View style={[styles.row, { borderBottomColor: theme.border }]}>
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="switch"
+      accessibilityState={{ checked: value, disabled }}
+      accessibilityLabel={label}
+      style={({ pressed }) => [
+        variant === 'card' ? styles.cardRow : styles.inlineRow,
+        variant === 'card' && {
+          backgroundColor: theme.cardElevated,
+          borderColor: theme.border,
+        },
+        {
+          opacity: disabled ? 0.5 : pressed ? 0.92 : 1,
+        },
+      ]}
+    >
       <View style={styles.left}>
-        {icon && <Text style={styles.icon}>{icon}</Text>}
+        {iconName && (
+          <View style={[styles.iconPill, { backgroundColor: theme.surface }]}>
+            <Ionicons name={iconName} size={16} color={theme.textPrimary} />
+          </View>
+        )}
         <View style={{ flex: 1 }}>
           <Text style={[styles.label, { color: theme.textPrimary }]}>{label}</Text>
           {description && (
@@ -28,27 +119,55 @@ const ToggleSwitch = React.memo(function ToggleSwitch({
           )}
         </View>
       </View>
-      <Switch
-        value={value}
-        onValueChange={onValueChange}
-        disabled={disabled}
-        trackColor={{ false: theme.border, true: theme.primary }}
-        thumbColor="#FFFFFF"
-        ios_backgroundColor={theme.border}
-      />
-    </View>
+
+      <Animated.View style={[styles.track, trackStyle]}>
+        <Animated.View
+          style={[
+            styles.thumb,
+            { backgroundColor: theme.surface, shadowColor: '#000' },
+            thumbStyle,
+          ]}
+        />
+      </Animated.View>
+    </Pressable>
   );
 });
 
 const styles = StyleSheet.create({
-  row: {
-    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-    paddingVertical: Spacing[4], borderBottomWidth: StyleSheet.hairlineWidth,
+  cardRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing[3],
+    paddingVertical: Spacing[3],
+    paddingHorizontal: Spacing[4],
+    borderRadius: Radius.xl,
+    borderWidth: StyleSheet.hairlineWidth,
   },
-  left:  { flexDirection: 'row', alignItems: 'center', flex: 1, gap: Spacing[3], marginRight: Spacing[3] },
-  icon:  { fontSize: 20 },
-  label: { fontSize: FontSize.base, fontWeight: FontWeight.medium },
-  desc:  { fontSize: FontSize.xs, marginTop: 2 },
+  inlineRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing[3],
+    paddingVertical: Spacing[3],
+  },
+  left:    { flexDirection: 'row', alignItems: 'center', flex: 1, gap: Spacing[3] },
+  iconPill: {
+    width: 32, height: 32, borderRadius: Radius.pill,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  label:   { fontSize: FontSize.sm, fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.snug },
+  desc:    { fontSize: FontSize.xs, marginTop: 2, lineHeight: FontSize.xs * 1.5 },
+  track: {
+    width: TRACK_W, height: TRACK_H,
+    borderRadius: Radius.pill,
+    borderWidth: StyleSheet.hairlineWidth,
+    justifyContent: 'center',
+  },
+  thumb: {
+    width: THUMB, height: THUMB,
+    borderRadius: THUMB / 2,
+    shadowOpacity: 0.18, shadowRadius: 3, shadowOffset: { width: 0, height: 1 },
+    elevation: 2,
+  },
 });
 
 export default ToggleSwitch;

--- a/mobile/components/UrgencyBanner.tsx
+++ b/mobile/components/UrgencyBanner.tsx
@@ -1,10 +1,16 @@
 // components/UrgencyBanner.tsx
+// Shows donor-availability context next to a posted request.
+// Uses theme tokens for soft tints (no alpha-hex hacks).
+
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@/contexts/ThemeContext';
-import { FontSize, FontWeight, Spacing, Radius, LetterSpacing } from '@/constants/Typography';
+import {
+  FontSize, FontWeight, Spacing, Radius, LetterSpacing,
+} from '@/constants/Typography';
 
-interface UrgencyBannerProps {
+export interface UrgencyBannerProps {
   donorCount: number;
   radiusKm: number;
   bloodGroup: string;
@@ -16,37 +22,60 @@ const UrgencyBanner = React.memo(function UrgencyBanner({
   donorCount, radiusKm, bloodGroup, isCountryWide, countryName,
 }: UrgencyBannerProps) {
   const { theme } = useTheme();
-  const critical = donorCount <= 3;
-  const color    = donorCount === 0 ? theme.error : critical ? theme.warning : theme.success;
 
-  const headline = donorCount === 0
-    ? isCountryWide
-      ? `No ${bloodGroup} donors found in ${countryName ?? 'your country'}`
-      : `No ${bloodGroup} donors within ${radiusKm} km — expanding search…`
-    : isCountryWide
-      ? `${donorCount} ${bloodGroup} donor${donorCount === 1 ? '' : 's'} found across ${countryName ?? 'your country'}`
-      : `Only ${donorCount} ${bloodGroup} donor${donorCount === 1 ? '' : 's'} within ${radiusKm} km`;
+  const tone =
+    donorCount === 0 ? { bg: theme.dangerSoft,  fg: theme.danger,  icon: 'alert-circle' as const }
+    : donorCount <= 3  ? { bg: theme.warningSoft, fg: theme.warning, icon: 'warning'      as const }
+    :                    { bg: theme.successSoft, fg: theme.success, icon: 'pulse'        as const };
+
+  const headline =
+    donorCount === 0
+      ? isCountryWide
+        ? `No ${bloodGroup} donors found in ${countryName ?? 'your country'}`
+        : `No ${bloodGroup} donors within ${radiusKm} km — expanding search`
+      : isCountryWide
+        ? `${donorCount} ${bloodGroup} donor${donorCount === 1 ? '' : 's'} across ${countryName ?? 'your country'}`
+        : `${donorCount} ${bloodGroup} donor${donorCount === 1 ? '' : 's'} within ${radiusKm} km`;
+
+  const sub =
+    donorCount > 0
+      ? 'Notifying compatible donors now. Every second counts.'
+      : "Your request is live. We'll notify donors as they appear.";
 
   return (
-    <View style={[styles.wrap, { backgroundColor: `${color}10`, borderColor: `${color}40` }]}>
-      <Text style={[styles.dot, { color }]}>●</Text>
+    <View
+      accessibilityRole="alert"
+      style={[
+        styles.wrap,
+        { backgroundColor: tone.bg, borderColor: tone.fg },
+      ]}
+    >
+      <View style={[styles.iconWrap, { backgroundColor: tone.fg + '22' }]}>
+        <Ionicons name={tone.icon} size={18} color={tone.fg} />
+      </View>
       <View style={{ flex: 1 }}>
-        <Text style={[styles.headline, { color }]}>{headline}</Text>
-        <Text style={[styles.sub, { color: theme.textSecondary }]}>
-          {donorCount > 0
-            ? 'Notifying compatible donors now. Every second counts.'
-            : 'Your request is live. We\'ll notify donors as they appear.'}
-        </Text>
+        <Text style={[styles.headline, { color: tone.fg }]}>{headline}</Text>
+        <Text style={[styles.sub, { color: theme.textMuted }]}>{sub}</Text>
       </View>
     </View>
   );
 });
 
 const styles = StyleSheet.create({
-  wrap:     { flexDirection: 'row', alignItems: 'flex-start', gap: Spacing[3], borderWidth: 1, borderRadius: Radius.sm, padding: Spacing[3] },
-  dot:      { fontSize: 10, marginTop: 3 },
-  headline: { fontSize: FontSize.sm, fontWeight: FontWeight.bold },
-  sub:      { fontSize: FontSize.xs, marginTop: 2, lineHeight: 18 },
+  wrap: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: Spacing[3],
+    padding: Spacing[3],
+    borderRadius: Radius.xl,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  iconWrap: {
+    width: 36, height: 36, borderRadius: Radius.pill,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  headline: { fontSize: FontSize.sm, fontWeight: FontWeight.bold, letterSpacing: LetterSpacing.snug },
+  sub:      { fontSize: FontSize.xs, marginTop: 2, lineHeight: FontSize.xs * 1.6 },
 });
 
 export default UrgencyBanner;

--- a/mobile/constants/BloodData.ts
+++ b/mobile/constants/BloodData.ts
@@ -53,9 +53,9 @@ export const URGENCY_LEVELS = ['critical', 'urgent', 'standard'] as const;
 export type UrgencyLevel = typeof URGENCY_LEVELS[number];
 
 export const URGENCY_CONFIG = {
-  critical: { label: 'Critical', color: '#FF2D55', icon: '🚨', minutes: 30 },
-  urgent:   { label: 'Urgent',   color: '#FFB300', icon: '⚠️', minutes: 120 },
-  standard: { label: 'Standard', color: '#00C853', icon: '🩸', minutes: 720 },
+  critical: { label: 'Critical', color: '#FF2D55', icon: 'flash',            minutes: 30  },
+  urgent:   { label: 'Urgent',   color: '#FFB300', icon: 'time',             minutes: 120 },
+  standard: { label: 'Standard', color: '#00C853', icon: 'calendar-outline', minutes: 720 },
 };
 
 export const GENDER_OPTIONS = ['Male', 'Female', 'Other', 'Prefer not to say'] as const;

--- a/mobile/contexts/AuthContext.tsx
+++ b/mobile/contexts/AuthContext.tsx
@@ -109,14 +109,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       'full_name', 'gender', 'date_of_birth', 'avatar_url',
       'blood_group', 'medical_conditions', 'share_medical_history',
       'is_available_to_donate', 'address',
+      'phone', 'whatsapp_available', 'role',
     ];
     for (const k of allowed) {
       if (k in updates) (patch as any)[k] = (updates as any)[k];
     }
     if (Object.keys(patch).length === 0) return;
 
-    await apiUpdateProfile(patch);
-    setProfile(prev => (prev ? { ...prev, ...patch } as UserProfile : prev));
+    // Use the server-returned row as the source of truth. The backend may
+    // normalise (e.g. role downgrade on age fail, trimmed strings). Merging
+    // patch into local first prevents flicker if the server response is slow.
+    const updated = await apiUpdateProfile(patch);
+    setProfile(prev => {
+      if (!prev) return prev;
+      const merged: UserProfile = { ...prev, ...(patch as Partial<UserProfile>) };
+      if (updated && typeof updated === 'object') {
+        Object.assign(merged, updated as Partial<UserProfile>);
+      }
+      return merged;
+    });
   }, [session]);
 
   useEffect(() => {

--- a/mobile/hooks/useDonorHeartbeat.ts
+++ b/mobile/hooks/useDonorHeartbeat.ts
@@ -1,0 +1,98 @@
+// hooks/useDonorHeartbeat.ts
+// Push the donor's live GPS to /donations/heartbeat while they're en-route to
+// the hospital. The recipient subscribes to realtime UPDATEs on
+// request_responses and renders a moving pin on /map/live.
+//
+// Foreground-only — when the donor backgrounds the app the watcher stops.
+// This matches Uber's actual "driver" UX (you keep the app open while
+// driving). Background-location is opt-in via a system permission prompt
+// and adds complexity / battery cost we don't justify yet.
+//
+// Heartbeat policy:
+//   • Push every 30 seconds OR every 50 metres of movement, whichever first.
+//   • Stop on unmount, on hook-disabled, or on a server 400/404 (donor no
+//     longer accepted on this request).
+
+import { useEffect, useRef } from 'react';
+import * as Location from 'expo-location';
+import { apiDonationHeartbeat } from '@/utils/api';
+import { errorReporter } from '@/lib/errorReporter';
+
+const HEARTBEAT_MIN_GAP_MS    = 30_000;
+const HEARTBEAT_MIN_DELTA_M   = 50;
+const LOCATION_TIME_INTERVAL  = 15_000; // watcher firing interval
+const LOCATION_DISTANCE_DELTA = 25;
+
+function metresBetween(
+  a: { latitude: number; longitude: number },
+  b: { latitude: number; longitude: number },
+): number {
+  const R = 6371000;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLon = toRad(b.longitude - a.longitude);
+  const x =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(a.latitude)) * Math.cos(toRad(b.latitude)) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(x), Math.sqrt(1 - x));
+}
+
+export function useDonorHeartbeat(requestId: string | undefined, enabled: boolean) {
+  const subRef         = useRef<Location.LocationSubscription | null>(null);
+  const lastPushAtRef  = useRef<number>(0);
+  const lastCoordsRef  = useRef<{ latitude: number; longitude: number } | null>(null);
+  const fatalErrorRef  = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (!enabled || !requestId) return;
+    fatalErrorRef.current = false;
+
+    (async () => {
+      const { status } = await Location.getForegroundPermissionsAsync();
+      if (status !== 'granted') {
+        const req = await Location.requestForegroundPermissionsAsync();
+        if (req.status !== 'granted') return;
+      }
+
+      subRef.current = await Location.watchPositionAsync(
+        {
+          accuracy: Location.Accuracy.High,
+          timeInterval: LOCATION_TIME_INTERVAL,
+          distanceInterval: LOCATION_DISTANCE_DELTA,
+        },
+        async (pos) => {
+          if (fatalErrorRef.current) return;
+          const coords = { latitude: pos.coords.latitude, longitude: pos.coords.longitude };
+          const now = Date.now();
+          const last = lastCoordsRef.current;
+          const movedEnough = !last || metresBetween(last, coords) >= HEARTBEAT_MIN_DELTA_M;
+          const cooledDown  = now - lastPushAtRef.current >= HEARTBEAT_MIN_GAP_MS;
+          if (!movedEnough && !cooledDown) return;
+
+          try {
+            await apiDonationHeartbeat(requestId, coords.latitude, coords.longitude);
+            lastPushAtRef.current = now;
+            lastCoordsRef.current = coords;
+          } catch (e: any) {
+            // 400/404 means the donor no longer accepts this request — stop.
+            const status = e?.status as number | undefined;
+            if (status === 400 || status === 404) {
+              fatalErrorRef.current = true;
+              subRef.current?.remove();
+              subRef.current = null;
+              return;
+            }
+            errorReporter.warn('Heartbeat failed', { requestId, message: e?.message });
+          }
+        },
+      );
+    })();
+
+    return () => {
+      subRef.current?.remove();
+      subRef.current = null;
+      lastPushAtRef.current = 0;
+      lastCoordsRef.current = null;
+    };
+  }, [requestId, enabled]);
+}

--- a/mobile/hooks/useRequests.ts
+++ b/mobile/hooks/useRequests.ts
@@ -209,9 +209,11 @@ export function useNearbyRequests(
       const resp = await apiListRequests(query);
       let list = (resp?.requests ?? []) as BloodRequest[];
 
-      // Defence-in-depth: client-side compatibility filter on top of the
-      // server's geo filter. Belt + suspenders until /requests supports
-      // `compatibleFor=<donorGroup>` server-side.
+      // Defence-in-depth: filter out the caller's own posts so they never see
+      // their own request in the donor feed, even if backend filtering lags.
+      if (uid) list = list.filter(r => r.recipient_id !== uid);
+
+      // Compatibility filter (donors only see groups they can donate to).
       const myBlood = myGroupRef.current;
       if (isDonorRef.current && myBlood) {
         list = list.filter(r =>

--- a/mobile/utils/api.ts
+++ b/mobile/utils/api.ts
@@ -112,6 +112,9 @@ export type ProfilePatch = Partial<{
   share_medical_history: boolean;
   is_available_to_donate: boolean;
   address: string | null;
+  phone: string | null;
+  whatsapp_available: boolean;
+  role: 'donor' | 'recipient' | 'both';
 }>;
 export const apiUpdateProfile = (patch: ProfilePatch) =>
   request<unknown>('PATCH', '/profiles/me', patch);
@@ -180,6 +183,9 @@ export const apiCompleteDonation = (requestId: string, donorId: string) =>
   );
 
 export const apiDonationHistory = () => request<any[]>('GET', '/donations/history');
+
+export const apiDonationHeartbeat = (requestId: string, latitude: number, longitude: number) =>
+  request<{ ok: true }>('POST', '/donations/heartbeat', { requestId, latitude, longitude });
 
 // ── Notifications ────────────────────────────────────────────────────────────
 export const apiRegisterPushToken = (token: string) =>

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -148,10 +148,18 @@ create table if not exists public.request_responses (
   request_id uuid not null references public.blood_requests(id) on delete cascade,
   donor_id   uuid not null references public.profiles(id)       on delete cascade,
   status     response_status_enum not null default 'pending',
+  -- Live donor location, pushed by the donor's app via /donations/heartbeat
+  -- while they're en-route to the hospital after accept. The recipient reads
+  -- this via the existing request_responses_select_visible policy.
+  donor_lat                  double precision,
+  donor_lon                  double precision,
+  donor_location_updated_at  timestamptz,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
 
-  constraint request_responses_unique unique (request_id, donor_id)
+  constraint request_responses_unique unique (request_id, donor_id),
+  constraint request_responses_donor_lat_range check (donor_lat is null or (donor_lat between -90  and 90)),
+  constraint request_responses_donor_lon_range check (donor_lon is null or (donor_lon between -180 and 180))
 );
 
 -- ────────────────────────────────────────────────────────────────────────────
@@ -262,18 +270,22 @@ security definer
 set search_path = public
 as $$
 declare
-  v_status         request_status_enum;
-  v_recipient_id   uuid;
-  v_units_needed   integer;
-  v_accepted_count integer;
-  v_existing       response_status_enum;
-  v_resp_id        uuid;
+  v_status            request_status_enum;
+  v_recipient_id      uuid;
+  v_units_needed      integer;
+  v_accepted_count    integer;
+  v_existing          response_status_enum;
+  v_resp_id           uuid;
+  v_other_commitment  uuid;
 begin
-  -- Lock the request row for the duration of this transaction
-  select status, recipient_id, units_needed
+  -- Lock the request row for the duration of this transaction.
+  -- Every column reference is alias-qualified — without that, PG treats
+  -- "status" as ambiguous between the table column and the RETURNS TABLE
+  -- output column with the same name (error 42702).
+  select br.status, br.recipient_id, br.units_needed
     into v_status, v_recipient_id, v_units_needed
-    from public.blood_requests
-   where id = p_request_id
+    from public.blood_requests br
+   where br.id = p_request_id
    for update;
 
   if not found then
@@ -292,31 +304,56 @@ begin
   end if;
 
   -- Idempotency: if donor already accepted, return existing record
-  select status into v_existing
-    from public.request_responses
-   where request_id = p_request_id and donor_id = p_donor_id
+  select rr.status into v_existing
+    from public.request_responses rr
+   where rr.request_id = p_request_id and rr.donor_id = p_donor_id
    for update;
 
   if v_existing = 'accepted' then
-    select id into v_resp_id from public.request_responses
-     where request_id = p_request_id and donor_id = p_donor_id;
-    return query select v_resp_id, 'accepted'::response_status_enum, 'Already accepted';
+    select rr.id into v_resp_id from public.request_responses rr
+     where rr.request_id = p_request_id and rr.donor_id = p_donor_id;
+    return query select v_resp_id, 'accepted'::response_status_enum, 'Already accepted'::text;
     return;
   end if;
 
   if v_existing = 'completed' then
-    select id into v_resp_id from public.request_responses
-     where request_id = p_request_id and donor_id = p_donor_id;
-    return query select v_resp_id, 'completed'::response_status_enum, 'Already completed';
+    select rr.id into v_resp_id from public.request_responses rr
+     where rr.request_id = p_request_id and rr.donor_id = p_donor_id;
+    return query select v_resp_id, 'completed'::response_status_enum, 'Already completed'::text;
+    return;
+  end if;
+
+  -- ────────────────────────────────────────────────────────────────────────
+  -- ONE-ACTIVE-COMMITMENT RULE
+  -- ────────────────────────────────────────────────────────────────────────
+  -- A donor can only have ONE outstanding `accepted` response at a time —
+  -- i.e. they cannot commit to a second request while a prior commitment is
+  -- still in flight on an `active` blood_request. The block clears when:
+  --   (a) the prior response is marked `completed` (donation recorded), or
+  --   (b) the prior request flips to `fulfilled`, `cancelled`, or `expired`.
+  -- Checked here (server-side), authoritative regardless of client state.
+  select rr.request_id
+    into v_other_commitment
+    from public.request_responses rr
+    join public.blood_requests br on br.id = rr.request_id
+   where rr.donor_id  = p_donor_id
+     and rr.status    = 'accepted'
+     and rr.request_id <> p_request_id
+     and br.status    = 'active'
+   limit 1;
+
+  if v_other_commitment is not null then
+    return query select null::uuid, null::response_status_enum,
+      'You already committed to another active request — complete or cancel that one first';
     return;
   end if;
 
   -- Capacity check inside the same transaction (race-free)
   select count(*)
     into v_accepted_count
-    from public.request_responses
-   where request_id = p_request_id
-     and status = 'accepted';
+    from public.request_responses rr
+   where rr.request_id = p_request_id
+     and rr.status = 'accepted';
 
   if v_accepted_count >= v_units_needed then
     return query select null::uuid, null::response_status_enum,
@@ -349,47 +386,51 @@ security definer
 set search_path = public
 as $$
 declare
-  v_status         request_status_enum;
-  v_recipient_id   uuid;
-  v_resp_status    response_status_enum;
-  v_resp_id        uuid;
-  v_new_total      integer;
+  v_status              request_status_enum;
+  v_recipient_id        uuid;
+  v_units_needed        integer;
+  v_completed_count     integer;
+  v_resp_status         response_status_enum;
+  v_resp_id             uuid;
+  v_new_total           integer;
 begin
-  select status, recipient_id
-    into v_status, v_recipient_id
-    from public.blood_requests
-   where id = p_request_id
+  select br.status, br.recipient_id, br.units_needed
+    into v_status, v_recipient_id, v_units_needed
+    from public.blood_requests br
+   where br.id = p_request_id
    for update;
 
   if not found then
-    return query select null::integer, 'Request not found';
+    return query select null::integer, 'Request not found'::text;
     return;
   end if;
 
   if v_recipient_id <> p_caller_id then
-    return query select null::integer, 'Not authorised';
+    return query select null::integer, 'Not authorised'::text;
     return;
   end if;
 
-  if v_status <> 'active' then
+  -- Accept either 'active' or already-flipped 'fulfilled' (idempotent path
+  -- when a multi-unit request partially completed but later gets revisited).
+  if v_status not in ('active','fulfilled') then
     return query select null::integer, format('Request already %s', v_status);
     return;
   end if;
 
-  select id, status
+  select rr.id, rr.status
     into v_resp_id, v_resp_status
-    from public.request_responses
-   where request_id = p_request_id and donor_id = p_donor_id
+    from public.request_responses rr
+   where rr.request_id = p_request_id and rr.donor_id = p_donor_id
    for update;
 
   if v_resp_id is null then
-    return query select null::integer, 'Donor has not accepted this request';
+    return query select null::integer, 'Donor has not accepted this request'::text;
     return;
   end if;
 
   if v_resp_status = 'completed' then
-    select total_donations into v_new_total from public.profiles where id = p_donor_id;
-    return query select v_new_total, 'Already completed';
+    select p.total_donations into v_new_total from public.profiles p where p.id = p_donor_id;
+    return query select v_new_total, 'Already completed'::text;
     return;
   end if;
 
@@ -398,15 +439,34 @@ begin
     return;
   end if;
 
+  -- Flip this donor's response to completed
   update public.request_responses set status = 'completed' where id = v_resp_id;
-  update public.blood_requests    set status = 'fulfilled', donor_id = p_donor_id where id = p_request_id;
-  update public.profiles
-     set total_donations    = total_donations + 1,
-         last_donation_date = now()
-   where id = p_donor_id
-  returning total_donations into v_new_total;
 
-  return query select v_new_total, 'OK';
+  -- Bump donor stats. Table alias disambiguates `total_donations` from the
+  -- RETURNS TABLE output column with the same name.
+  update public.profiles p
+     set total_donations    = p.total_donations + 1,
+         last_donation_date = now()
+   where p.id = p_donor_id;
+
+  select p.total_donations into v_new_total
+    from public.profiles p
+   where p.id = p_donor_id;
+
+  -- N donors = N units: only flip the REQUEST to fulfilled when all units
+  -- are completed. A 3-unit request stays active until 3 distinct donors
+  -- have completed.
+  select count(*) into v_completed_count
+    from public.request_responses rr
+   where rr.request_id = p_request_id and rr.status = 'completed';
+
+  if v_completed_count >= v_units_needed then
+    update public.blood_requests
+       set status = 'fulfilled', donor_id = p_donor_id
+     where id = p_request_id;
+  end if;
+
+  return query select v_new_total, 'OK'::text;
 end $$;
 
 -- ────────────────────────────────────────────────────────────────────────────
@@ -469,6 +529,35 @@ create policy "profiles_select_own"
   on public.profiles for select
   using (auth.uid() = id);
 
+-- ── Mutual-commitment disclosure ──────────────────────────────────────────
+-- Once a donor accepts a recipient's request, both parties need to see each
+-- other's profile (name, contact, blood group, eligibility) to coordinate the
+-- donation. This second permissive SELECT policy unlocks the join so the
+-- request detail screen can render the ProfileCard for the other party.
+--   • Visibility opens on `accepted` and stays open through `completed` so
+--     post-donation chat and follow-up still resolve names.
+--   • A `declined` response does NOT unlock anything.
+-- (Multiple policies on the same op are OR-ed by Postgres, so this stays
+-- additive on top of `profiles_select_own`.)
+drop policy if exists "profiles_select_mutual_commitment" on public.profiles;
+create policy "profiles_select_mutual_commitment"
+  on public.profiles for select
+  using (
+    exists (
+      select 1
+        from public.request_responses rr
+        join public.blood_requests   br on br.id = rr.request_id
+       where rr.status in ('accepted', 'completed')
+         and (
+           -- profiles.id is the donor who accepted my (recipient's) request
+           (rr.donor_id     = profiles.id and br.recipient_id = auth.uid())
+           or
+           -- profiles.id is the recipient whose request I (donor) accepted
+           (br.recipient_id = profiles.id and rr.donor_id     = auth.uid())
+         )
+    )
+  );
+
 -- Insert: only via the auth.users trigger (auto-creates row). Authenticated
 -- users can also insert their own row in case the trigger is missing.
 create policy "profiles_insert_own"
@@ -496,10 +585,14 @@ declare
   v_is_service_role boolean;
 begin
   -- Service role bypasses this entirely
-  v_is_service_role := coalesce(
-    current_setting('request.jwt.claim.role', true) = 'service_role',
-    false
-  );
+  -- Multiple detection methods OR-ed — empirically a single check
+  -- (current_setting on the JWT claim) returns NULL in some PostgREST
+  -- configurations even for service_role connections.
+  v_is_service_role :=
+       current_user = 'service_role'
+    or current_role = 'service_role'
+    or coalesce(nullif(current_setting('request.jwt.claim.role', true), ''), '') = 'service_role'
+    or coalesce(nullif(current_setting('request.jwt.claims', true), '')::jsonb->>'role', '') = 'service_role';
   if v_is_service_role then
     return new;
   end if;
@@ -589,10 +682,14 @@ as $$
 declare
   v_is_service_role boolean;
 begin
-  v_is_service_role := coalesce(
-    current_setting('request.jwt.claim.role', true) = 'service_role',
-    false
-  );
+  -- Multiple detection methods OR-ed — empirically a single check
+  -- (current_setting on the JWT claim) returns NULL in some PostgREST
+  -- configurations even for service_role connections.
+  v_is_service_role :=
+       current_user = 'service_role'
+    or current_role = 'service_role'
+    or coalesce(nullif(current_setting('request.jwt.claim.role', true), ''), '') = 'service_role'
+    or coalesce(nullif(current_setting('request.jwt.claims', true), '')::jsonb->>'role', '') = 'service_role';
   if v_is_service_role then
     return new;
   end if;


### PR DESCRIPTION
Locks the (tabs)/request.tsx visual + interaction language as the canonical reference (REDESIGN_PLAN.md §14), then propagates it through every screen, modal, and shared component. Adds the one-active-commitment rule, mutual- disclosure RLS, monochrome dead-state / green-fulfilled cards, silent pull-to-refresh, in-app chat (no email), unified ToggleSwitch pill, address editing in profile/edit, and a 21-section production README.

Mobile
------
- (auth)/index.tsx, onboarding.tsx, profile/edit.tsx rewritten to the Request-screen sheet pattern: hero zone, -Spacing[5] sheet overlap, brand accent strip + handle, spring entrance, inline CTA with summary row + footer micro-copy, Haptics on every Pressable.
- (tabs)/index, donors, my-requests, history, profile aligned: SectionLabel pattern (uppercase / black / widest tracking / textMuted), Haptics, toast- wired error paths.
- (tabs)/_layout: my-requests now visible to all roles (any user who can post a request must be able to manage their posts).
- (tabs)/index home: ACTIVE COMMITMENT banner (Uber "ride in progress" pattern), Nearby-requests feed-empty Section kind under the feed header when compatible.length === 0.
- Truly silent pull-to-refresh on all four tabs: refreshing hard-coded false so no native spinner ever activates and no layout space is allocated; gesture still fires onRefresh.
- chat.tsx: KeyboardAvoidingView now handles Android via behavior='height'; composer inset baked into paddingBottom so the input never hides behind the keyboard or sits on the Android gesture indicator. Single Chat pill per profile via messageContact (no more email mailto:).
- request/[id].tsx: openMaps declaration order fixed; per-donor live-GPS status pill on recipient view; aggregate "Track donor live" CTA with waiting fallback when no heartbeat; "View full profile" CTA on both sides; one-active-commitment guard surfaces a warning pill + "Open my active commitment" deep-link instead of letting the donor tap Accept.
- donor/[id].tsx: Message button opens in-app chat (no mailto), accepts optional requestId param from upstream callers, discovers the mutual- commitment thread when not passed.
- map/live.tsx: emojis replaced with Ionicons, theme.glass/accent legacy tokens swapped to theme.surface/primary, Haptics on close/fit/maps.
- Unified ToggleSwitch as the canonical 2026 pill (Reanimated v4 thumb + interpolated track colour + Haptics). Replaces three different inline toggle implementations across profile, profile/edit, and onboarding.
- Donor settings card uses ToggleSwitch variant='inline' + hairline divider so nested rounded rectangles don't compete.
- RequestCard status colorway: active = urgency tone, fulfilled = success green ("Fulfilled · life saved"), cancelled = grey ("Cancelled"), expired = grey ("Expired") with 0.78 opacity and soft blood badge.
- profile/edit adds address (multiline) and DOB is now nullable so a donor can't silently bypass the age gate via the 2000-01-01 default.
- Pill/rectangle radius audit across 7 files: 24 offenders promoted from Radius.sm/md/lg/xs to Radius.xl (cards/banners) or Radius.pill (chips/badges/action buttons); chat bubbles keep their iMessage tail.
- SelectSheet + CustomAlert get the brand accent strip + handle so modals match the Request-screen sheet language.

Backend
-------
- accept_blood_request RPC adds the one-active-commitment rule: a donor with any 'accepted' response on an 'active' request cannot accept another until the prior commitment completes or cancels.
- profileController PATCH /profiles/me now exercises avatar_url + address in ALLOWED_FIELDS and re-validates the donor-age gate when role flips.

Schema
------
- supabase_schema.sql + migrations/2026-05-12-one-active-commitment-and- mutual-disclosure.sql:
    * accept_blood_request RPC (one-active-commitment guard).
    * profiles_select_mutual_commitment RLS policy — opens the donor↔ recipient profile join the moment an accepted/completed response exists between them. Fixes "name / call / message buttons silently empty on the request detail screen".

Docs
----
- README.md: full 21-section production rewrite per architect spec — badges, Mermaid architecture + N-donors + geo-fence diagrams, FAQ, contributing guide, author footer keyed to aashir-athar, zero emojis.
- REDESIGN_PLAN.md §14 locks the canonical Request-screen design language as the reference + the 100%-wired mandate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Live donor GPS location tracking during active donations
  * Profile editing screen for managing account details and role
  * Map-based blood request creation with hospital location selection
  * Enhanced donor discovery with real-time location map view
  * Expanded navigation access for donors across tabs

* **Bug Fixes**
  * Donors can no longer accept multiple simultaneous requests
  * Users no longer see their own requests in donor discovery feed
  * Lives helped metric now reflects actual donation count

* **Improvements**
  * Complete visual redesign with enhanced animations and haptic feedback
  * Updated authentication and onboarding experience
  * Improved request and profile management interfaces

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aashir-athar/BludStack-RN/pull/3)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->