### PR TITLE
fix(backend): PATCH /profiles/me accepts null address (was rejecting …

### DIFF
--- a/backend/src/routes/profiles.js
+++ b/backend/src/routes/profiles.js
@@ -42,7 +42,11 @@ router.patch(
     body('share_medical_history').optional().isBoolean(),
     body('is_available_to_donate').optional().isBoolean(),
     body('push_token').optional().isString().isLength({ max: 200 }),
-    body('address').optional().isString().isLength({ max: 300 }),
+    // `optional({ nullable: true })` so an explicit `null` from the client
+    // (mobile sends `address.trim() || null` to clear the column) skips the
+    // .isString() check. Without this, "clear the address" returns
+    // "address: Invalid value" — surfaced on profile/edit save.
+    body('address').optional({ nullable: true }).isString().isLength({ max: 300 }),
   ],
   validate,
   updateMyProfile,


### PR DESCRIPTION
…clear-address with 400)

The validator on PATCH /api/v1/profiles/me had
    body('address').optional().isString()…
which, in express-validator, only treats `undefined` as "missing". The mobile profile/edit modal sends `address: address.trim() || null` so the recipient can clear the column. `null` then failed `.isString()` and the server returned a confusing
    { field: 'address', message: 'Invalid value' }
visible in the user-reported toast when changing role.

Match the same `optional({ nullable: true })` pattern already used by auth/register's `phone` and `date_of_birth` validators so explicit nulls are accepted as "clear this column".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation handling for the address field in user profiles, allowing null values to clear the field without triggering validation errors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aashir-athar/BludStack-RN/pull/5)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->