### PR TITLE
fix: contact-channel closure on request seal + donor age window 18-65…

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -76,7 +76,10 @@ async function register(req, res, next) {
       if (age === null) {
         return error(res, 'date_of_birth is required to register as a donor', 400);
       }
-      if (age < 18) {
+      // Donor eligibility window: 18-65 (WHO + most national blood-bank
+      // guidelines). Outside this window, downgrade silently to recipient
+      // — the caller gets `downgraded: true` and can surface a toast.
+      if (age < 18 || age > 65) {
         role = 'recipient';
         downgraded = true;
       }
@@ -111,7 +114,7 @@ async function register(req, res, next) {
       res,
       { profile: data, downgraded },
       downgraded
-        ? 'Profile created. Donor role requires age 18+, account set up as recipient.'
+        ? 'Profile created. Donor role requires age 18–65; account set up as recipient.'
         : 'Profile created',
       201,
     );

--- a/backend/src/controllers/profileController.js
+++ b/backend/src/controllers/profileController.js
@@ -82,8 +82,9 @@ async function updateMyProfile(req, res, next) {
         }
         const ageMs = Date.now() - new Date(dobIso).getTime();
         const ageYears = ageMs / (365.25 * 86_400_000);
-        if (ageYears < 18) {
-          return error(res, 'Donor role requires age 18+', 400);
+        // Donor eligibility window: 18-65 inclusive (WHO standard).
+        if (ageYears < 18 || ageYears > 65) {
+          return error(res, 'Donor role requires age 18–65', 400);
         }
       }
       updates.role = req.body.role;

--- a/migrations/2026-05-14-donor-max-age.sql
+++ b/migrations/2026-05-14-donor-max-age.sql
@@ -1,0 +1,60 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Migration: 2026-05-14 — add maximum donor age (65)
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Run once in Supabase Studio → SQL Editor. Idempotent and safe to re-run.
+--
+-- Tightens the existing profiles_donor_age CHECK constraint:
+--   was:  donors must be 18+
+--   now:  donors must be 18-65 inclusive (WHO whole-blood guideline)
+--
+-- The mobile client + backend (authController, profileController) already
+-- enforce the same window — this DB constraint is the final guard against
+-- direct service_role writes that bypass the application layer.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+set search_path = public;
+
+-- Reject the migration up front if any existing donor row already violates
+-- the new ceiling. The operator must decide what to do with them (downgrade
+-- to recipient, or grant an exception) before the constraint lands — silent
+-- corruption is worse than a noisy abort.
+do $$
+declare
+  v_violators int;
+begin
+  select count(*)
+    into v_violators
+    from public.profiles
+   where role in ('donor', 'both')
+     and date_of_birth is not null
+     and date_of_birth <= (current_date - interval '66 years');
+
+  if v_violators > 0 then
+    raise exception
+      'cannot tighten profiles_donor_age: % donor/both row(s) are older than 65. Downgrade them to recipient first, then re-run.',
+      v_violators;
+  end if;
+end $$;
+
+-- Drop + recreate so the constraint definition is the single source of
+-- truth on every re-run (Postgres has no "alter check constraint" verb).
+alter table public.profiles drop constraint if exists profiles_donor_age;
+
+alter table public.profiles add constraint profiles_donor_age check (
+  role = 'recipient'
+  or date_of_birth is null
+  or (
+        date_of_birth <= (current_date - interval '18 years')
+    and date_of_birth >  (current_date - interval '66 years')
+  )
+);
+
+-- ── Verify (single-row PASS/FAIL diagnostic) ─────────────────────────────────
+select
+  case
+    when (select pg_get_constraintdef(oid)
+            from pg_constraint
+           where conname = 'profiles_donor_age') ilike '%66 years%'
+    then 'PASS · donor max age (65) enforced'
+    else 'FAIL · re-run the migration'
+  end as result;

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -102,8 +102,19 @@ function RootNavigator() {
   const navReady = !loading && !!session && !!profile?.full_name;
   useNotificationDeepLinks(navReady);
 
+  // Hide the native splash exactly ONCE per app lifetime. SDK 54's splash
+  // screen module unregisters itself on the first hideAsync(); calling it
+  // again throws "No native splash screen registered for given view
+  // controller". Without the ref guard, every loading flip
+  // (sign-out → re-auth, profile refresh, etc.) re-triggers this effect
+  // and the second call fails loudly.
+  const splashHiddenRef = useRef(false);
   useEffect(() => {
-    if (!loading) SplashScreen.hideAsync();
+    if (loading || splashHiddenRef.current) return;
+    splashHiddenRef.current = true;
+    // Swallow rejection — if some other code path raced us to it, the
+    // splash is already gone and the user-visible behaviour is identical.
+    SplashScreen.hideAsync().catch(() => {});
   }, [loading]);
 
   // ── App flow (single source of truth) ─────────────────────────────────

--- a/mobile/app/donor/[id].tsx
+++ b/mobile/app/donor/[id].tsx
@@ -103,6 +103,11 @@ export default function DonorDetailScreen() {
     const [chatRequestId, setChatRequestId] = useState<string | null>(
         passedRequestId ?? null,
     );
+    // Whether the mutual-commitment request is STILL `active`. Call, WhatsApp
+    // and Chat all close together once the request flips to fulfilled /
+    // cancelled / expired — consistent with the closed-state banner in
+    // request/[id].tsx + chat.tsx. Null while we're still loading.
+    const [commitmentActive, setCommitmentActive] = useState<boolean | null>(null);
 
     // Subtle entrance animation for the avatar
     const fadeAnim = useRef(new Animated.Value(0)).current;
@@ -164,16 +169,34 @@ export default function DonorDetailScreen() {
         Promise.all([fetchDonor(), fetchResponses()]).finally(() => setLoading(false));
     }, [id]);
 
-    // Discover a chat thread when no requestId was passed via query param.
-    // Looks for any accepted/completed response between the viewer and the
-    // donor on either side (donor accepted my request, or I accepted theirs)
-    // and uses the most recent one. The mutual-commitment RLS policy makes
-    // this read safe for both parties.
+    // Discover a chat thread between the viewer and this profile.
+    // Looks for any accepted/completed response on either side and uses the
+    // most recent one. Also reads the parent request's `status` so we can
+    // close Call / WhatsApp / Chat when the request is no longer active.
+    // The mutual-commitment RLS policy makes both reads safe.
     useEffect(() => {
-        if (passedRequestId || !user?.id || !id || user.id === id) return;
+        if (!user?.id || !id || user.id === id) return;
         let cancelled = false;
+
+        const resolveActiveFor = async (rid: string) => {
+            const { data: br } = await supabase
+                .from('blood_requests')
+                .select('status')
+                .eq('id', rid)
+                .maybeSingle();
+            if (cancelled) return;
+            setCommitmentActive(br?.status === 'active');
+        };
+
         (async () => {
             try {
+                // If the caller passed a requestId, use it directly.
+                if (passedRequestId) {
+                    setChatRequestId(passedRequestId);
+                    await resolveActiveFor(passedRequestId);
+                    return;
+                }
+
                 // Path A: this profile is a donor who accepted MY (viewer = recipient's) request
                 const { data: aData } = await supabase
                     .from('request_responses')
@@ -187,7 +210,9 @@ export default function DonorDetailScreen() {
 
                 if (cancelled) return;
                 if ((aData as any)?.request_id) {
-                    setChatRequestId((aData as any).request_id);
+                    const rid: string = (aData as any).request_id;
+                    setChatRequestId(rid);
+                    await resolveActiveFor(rid);
                     return;
                 }
 
@@ -204,14 +229,39 @@ export default function DonorDetailScreen() {
 
                 if (cancelled) return;
                 if ((bData as any)?.request_id) {
-                    setChatRequestId((bData as any).request_id);
+                    const rid: string = (bData as any).request_id;
+                    setChatRequestId(rid);
+                    await resolveActiveFor(rid);
+                    return;
                 }
+
+                // No mutual commitment found at all → no active channel.
+                setCommitmentActive(false);
             } catch (e: any) {
                 if (!cancelled) console.warn('[DonorDetail chat-thread]', e?.message);
             }
         })();
         return () => { cancelled = true; };
     }, [passedRequestId, user?.id, id]);
+
+    // Watch the discovered request's status so the contact channels close
+    // the moment it flips to fulfilled / cancelled / expired without the
+    // user navigating away and back.
+    useEffect(() => {
+        if (!chatRequestId) return;
+        const ch = supabase
+            .channel(`donor_detail_req_${chatRequestId}_${Date.now()}`)
+            .on('postgres_changes', {
+                event: 'UPDATE', schema: 'public',
+                table: 'blood_requests',
+                filter: `id=eq.${chatRequestId}`,
+            }, (payload: any) => {
+                const s = payload?.new?.status;
+                if (s !== undefined) setCommitmentActive(s === 'active');
+            })
+            .subscribe();
+        return () => { supabase.removeChannel(ch); };
+    }, [chatRequestId]);
 
     // ── Derived values ───────────────────────────────────────────────────────
     const isOwnProfile = user?.id === id;
@@ -240,14 +290,29 @@ export default function DonorDetailScreen() {
         .map(n => n[0]?.toUpperCase() ?? '')
         .join('') ?? '';
 
+    // Channels are open ONLY while the mutual-commitment request is active.
+    // Once it flips to fulfilled / cancelled / expired, Call + WhatsApp +
+    // Chat all close together — consistent with the closed-state banner in
+    // request/[id].tsx and the chat composer in chat.tsx.
+    const channelsOpen = commitmentActive === true;
+
     // ── Contact actions ──────────────────────────────────────────────────────
+    // Call uses ONLY the phone column. Email is never a contact channel —
+    // users coordinate via Phone, WhatsApp (when the other party has
+    // whatsapp_available toggled on), or in-app Chat.
     const handleCall = useCallback(() => {
         if (!donor) return;
-        const target = donor.phone ?? donor.email;
-        if (!target) return Alert.alert('No contact info', 'This donor has not shared contact details.');
+        if (!channelsOpen) {
+            Alert.alert('Channel closed', 'This request is no longer active. Call, WhatsApp and chat are closed.');
+            return;
+        }
+        if (!donor.phone) {
+            Alert.alert('No phone shared', "This user hasn't added a phone number. Use chat to reach them.");
+            return;
+        }
         Haptics.selectionAsync().catch(() => {});
-        Linking.openURL(donor.phone ? `tel:${donor.phone}` : `mailto:${donor.email}`);
-    }, [donor]);
+        Linking.openURL(`tel:${donor.phone}`);
+    }, [donor, channelsOpen]);
 
     // In-app chat — NEVER email. Chat threads are scoped to a request_id so
     // both parties open the same conversation that lives behind the existing
@@ -256,6 +321,11 @@ export default function DonorDetailScreen() {
     const handleMessage = useCallback(() => {
         if (!donor || !user?.id) return;
         if (user.id === donor.id) return; // can't message yourself
+        if (!channelsOpen) {
+            Alert.alert('Channel closed', 'This request is no longer active. Chat is closed.');
+            return;
+        }
+        // From here on, follow the existing chatRequestId flow.
         if (!chatRequestId) {
             Alert.alert(
                 'No active thread yet',
@@ -272,7 +342,7 @@ export default function DonorDetailScreen() {
                 receiverName: encodeURIComponent(donor.full_name ?? 'Donor'),
             },
         });
-    }, [donor, user?.id, chatRequestId, router]);
+    }, [donor, user?.id, chatRequestId, router, channelsOpen]);
 
     const handleOpenMap = useCallback(() => {
         if (!donor?.latitude || !donor?.longitude) return;
@@ -512,22 +582,38 @@ export default function DonorDetailScreen() {
                     </Text>
                 </View>
 
-                {/* ── Contact actions ── */}
+                {/* ── Contact actions ──
+                    Call + Message are open only while the mutual-commitment
+                    request is still active. After fulfillment / cancellation
+                    / expiry, the buttons are disabled and a soft banner
+                    explains why — matches the closed-state behaviour on
+                    request/[id].tsx and chat.tsx. */}
                 {!isOwnProfile && (
                     <View style={styles.actionWrap}>
+                        {commitmentActive === false && (
+                            <View style={[styles.liveWaitPill, { backgroundColor: theme.cardElevated, borderColor: theme.border }]}>
+                                <View style={[styles.liveWaitDot, { backgroundColor: theme.textMuted }]} />
+                                <Text style={[styles.liveWaitText, { color: theme.textMuted }]} numberOfLines={2}>
+                                    Channels closed — this request is no longer active.
+                                </Text>
+                            </View>
+                        )}
                         <Button
-                            label="Call donor"
-                            icon={<Ionicons name="call" size={16} color="#fff" />}
+                            label="Call"
+                            icon={<Ionicons name="call" size={16} color={theme.textOnPrimary} />}
                             variant="primary"
                             size="lg"
                             onPress={handleCall}
+                            disabled={!channelsOpen}
                             fullWidth
                         />
                         <Button
-                            label="✉️  Send Message"
+                            label="Message"
+                            icon={<Ionicons name="chatbubble-ellipses-outline" size={16} color={theme.textPrimary} />}
                             variant="outline"
                             size="md"
                             onPress={handleMessage}
+                            disabled={!channelsOpen}
                             fullWidth
                         />
                     </View>
@@ -663,4 +749,11 @@ const styles = StyleSheet.create({
 
     // Actions
     actionWrap: { gap: Spacing[3] },
+    liveWaitPill: {
+        flexDirection: 'row', alignItems: 'center', gap: Spacing[2],
+        paddingHorizontal: Spacing[3], paddingVertical: Spacing[2],
+        borderRadius: Radius.pill, borderWidth: StyleSheet.hairlineWidth,
+    },
+    liveWaitDot: { width: 8, height: 8, borderRadius: 4 },
+    liveWaitText: { flex: 1, fontSize: FontSize.xs, fontWeight: FontWeight.semibold, letterSpacing: LetterSpacing.snug },
 });

--- a/mobile/app/onboarding.tsx
+++ b/mobile/app/onboarding.tsx
@@ -49,6 +49,11 @@ import {
 import { errorReporter } from '@/lib/errorReporter';
 
 const MIN_DONOR_AGE = 18;
+// WHO + most national blood-bank guidelines cap whole-blood donation at 65.
+// Above that, the cardiovascular load of a 450 ml draw isn't safe to assume
+// without a doctor's individual sign-off — out of scope for an app gate.
+// Recipients have no upper-age limit.
+const MAX_DONOR_AGE = 65;
 
 type StepKey =
   | 'role'
@@ -152,7 +157,12 @@ export default function OnboardingScreen() {
 
   // Role-aware step ordering — donors/both see DOB + medical; recipients skip.
   const steps = useMemo<StepKey[]>(() => {
-    if (form.role === 'recipient') return ['role', 'identity', 'blood', 'contact', 'confirm'];
+    // DOB is shown to EVERY role.
+    //   • Donor / Both → required + age-gated 18+ (validated below).
+    //   • Recipient    → optional, can leave blank and continue. DobStep's
+    //                    subtitle reads "Optional — helps us serve you better"
+    //                    when roleRequiresAge18 is false.
+    if (form.role === 'recipient') return ['role', 'identity', 'dob', 'blood', 'contact', 'confirm'];
     if (form.role === '')          return ['role'];
     return ['role', 'identity', 'dob', 'blood', 'medical', 'contact', 'confirm'];
   }, [form.role]);
@@ -203,11 +213,21 @@ export default function OnboardingScreen() {
         break;
       case 'dob': {
         const iso = dobISO();
-        if (!iso) { setError('dob', 'Enter a valid date of birth'); return false; }
+        const isDonorLike = form.role === 'donor' || form.role === 'both';
+        // Recipients can skip DOB entirely — leave blank and continue.
+        // Donors / Both must enter a valid DOB AND be 18+.
+        if (!iso) {
+          if (isDonorLike) { setError('dob', 'Enter a valid date of birth'); return false; }
+          break; // recipient: blank DOB is allowed
+        }
         const age = computeAge(iso);
         if (age === null || age < 1 || age > 120) { setError('dob', "That date doesn't look right"); return false; }
-        if ((form.role === 'donor' || form.role === 'both') && age < MIN_DONOR_AGE) {
+        if (isDonorLike && age < MIN_DONOR_AGE) {
           setError('dob', `Donors must be ${MIN_DONOR_AGE} or older — switch to "Receive only" if you'd like to keep going`);
+          return false;
+        }
+        if (isDonorLike && age > MAX_DONOR_AGE) {
+          setError('dob', `Donors must be ${MAX_DONOR_AGE} or younger — switch to "Receive only" if you'd like to keep going`);
           return false;
         }
         break;
@@ -245,7 +265,7 @@ export default function OnboardingScreen() {
 
       if (downgraded) {
         toast.warning('Switched to recipient', {
-          description: `Donors must be ${MIN_DONOR_AGE}+. You can still post requests anytime.`,
+          description: `Donors must be ${MIN_DONOR_AGE}–${MAX_DONOR_AGE}. You can still post requests anytime.`,
           duration: 6000,
         });
       } else {
@@ -616,7 +636,11 @@ function DobStep({
   onPickerChange: (e: DateTimePickerEvent, d?: Date) => void;
 }) {
   const { theme } = useTheme();
-  const eligible = age !== null && age >= MIN_DONOR_AGE;
+  // Donor eligibility window: 18-65 inclusive. Outside this range we surface
+  // a warning pill and (on submit) downgrade to recipient.
+  const tooYoung = age !== null && age < MIN_DONOR_AGE;
+  const tooOld   = age !== null && age > MAX_DONOR_AGE;
+  const eligible = age !== null && !tooYoung && !tooOld;
   const showHelper = age !== null;
 
   return (
@@ -674,9 +698,11 @@ function DobStep({
           />
           <Text style={[dobHelperStyles.text, { color: theme.textPrimary }]}>
             {`You're ${age}. `}
-            {roleRequiresAge18 && !eligible
+            {roleRequiresAge18 && tooYoung
               ? `Donors need to be ${MIN_DONOR_AGE}+ — we'll switch you to recipient.`
-              : 'Looks good.'}
+              : roleRequiresAge18 && tooOld
+                ? `Donors must be ${MAX_DONOR_AGE} or younger — we'll switch you to recipient.`
+                : 'Looks good.'}
           </Text>
         </View>
       )}

--- a/mobile/app/profile/edit.tsx
+++ b/mobile/app/profile/edit.tsx
@@ -43,6 +43,7 @@ import {
 import { errorReporter } from '@/lib/errorReporter';
 
 const MIN_DONOR_AGE = 18;
+const MAX_DONOR_AGE = 65;
 
 // Sheet entrance — identical physics to Request screen and onboarding.
 function useSheetEntrance() {
@@ -187,6 +188,7 @@ export default function ProfileEditScreen() {
     if (phone.trim() && phone.replace(/\D/g, '').length < 7) return 'Phone number looks too short';
     if (role === 'donor' || role === 'both') {
       if (!age || age < MIN_DONOR_AGE) return `Donors must be ${MIN_DONOR_AGE} or older`;
+      if (age > MAX_DONOR_AGE)         return `Donors must be ${MAX_DONOR_AGE} or younger`;
     }
     return null;
   }, [fullName, bloodGroup, phone, role, age]);

--- a/mobile/app/request/[id].tsx
+++ b/mobile/app/request/[id].tsx
@@ -264,10 +264,17 @@ export default function RequestDetailScreen() {
     );
   }, [id, user?.id, responses, fetchRequest]);
 
+  // Call ONLY uses the phone column. No email fallback — email is never an
+  // in-app contact channel; users coordinate via Phone, WhatsApp (when the
+  // other party has whatsapp_available toggled on), or in-app Chat.
   const callContact = useCallback((contact: any) => {
-    const phone = contact?.phone ?? contact?.email;
-    if (phone) Linking.openURL(`tel:${phone}`);
-  }, []);
+    if (!contact?.phone) {
+      toast.info('No phone shared', { description: 'Use chat to reach them — they haven\'t added a phone number.' });
+      return;
+    }
+    Haptics.selectionAsync().catch(() => {});
+    Linking.openURL(`tel:${contact.phone}`);
+  }, [toast]);
 
   // In-app chat scoped to this request — NEVER email. The mutual-commitment
   // RLS guarantees both parties can resolve each other's profile, so the
@@ -437,6 +444,7 @@ export default function RequestDetailScreen() {
               profile={request.recipient as any}
               onCall={() => callContact(request.recipient)}
               onMessage={() => messageContact(request.recipient)}
+              interactive={isActive}
             />
             <Button
               label="View full profile"
@@ -470,11 +478,14 @@ export default function RequestDetailScreen() {
                   profile={resp.donor as any}
                   onCall={() => callContact(resp.donor)}
                   onMessage={() => messageContact(resp.donor)}
+                  interactive={isActive}
                 />
 
                 {/* Per-donor heartbeat status pill (recipient view).
-                    Shows whether THIS specific donor is sharing live GPS. */}
-                {(resp as any).donor_lat != null ? (
+                    Only renders while the request is still active — once
+                    fulfilled / cancelled / expired the live channel closes
+                    along with chat + call + WhatsApp. */}
+                {isActive && ((resp as any).donor_lat != null ? (
                   <View style={[styles.liveWaitPill, { backgroundColor: theme.successSoft, borderColor: theme.success }]}>
                     <View style={[styles.liveWaitDot, { backgroundColor: theme.success }]} />
                     <Text style={[styles.liveWaitText, { color: theme.success }]} numberOfLines={1}>
@@ -488,7 +499,7 @@ export default function RequestDetailScreen() {
                       Waiting for {(resp.donor as any).full_name?.split(' ')[0] ?? 'donor'} to share GPS
                     </Text>
                   </View>
-                )}
+                ))}
 
                 {/* No duplicate Message button — the ProfileCard's Chat pill
                     already opens this thread via messageContact(). One chat
@@ -511,11 +522,12 @@ export default function RequestDetailScreen() {
               </View>
             ))}
 
-            {/* Live tracking — always render once a donor accepts (Uber-driver
-                UX). When a heartbeat exists, the button is primary; until then
+            {/* Live tracking — only while the request is active. Closes
+                with chat / call / WhatsApp once the request seals.
+                When a heartbeat exists, the button is primary; until then
                 we show a soft "waiting for GPS" pill so the recipient knows
                 tracking is wired and pending, not missing. */}
-            {(() => {
+            {isActive && (() => {
               const hasHeartbeat = acceptedResponses.some(r => (r as any).donor_lat != null);
               return hasHeartbeat ? (
                 <Button

--- a/mobile/components/ProfileCard.tsx
+++ b/mobile/components/ProfileCard.tsx
@@ -39,10 +39,18 @@ export interface ProfileCardProps {
   onCall?: () => void;
   onMessage?: () => void;
   onWhatsApp?: () => void;
+  /**
+   * When false, the entire contact-pills row (Call / WhatsApp / Chat) is
+   * hidden. Use this once the parent request is no longer active so all
+   * contact channels close together with chat (consistent with the
+   * "chat closed" banner shown when a request flips to fulfilled /
+   * cancelled / expired). Default true keeps backwards-compat.
+   */
+  interactive?: boolean;
 }
 
 const ProfileCard = React.memo(function ProfileCard({
-  profile, compact, onPress, onCall, onMessage, onWhatsApp,
+  profile, compact, onPress, onCall, onMessage, onWhatsApp, interactive = true,
 }: ProfileCardProps) {
   const { theme } = useTheme();
   const { canDonate, daysLeft } = canDonateAgain(profile.last_donation_date);
@@ -121,10 +129,13 @@ const ProfileCard = React.memo(function ProfileCard({
         </View>
       )}
 
-      {/* Contact pill row — only shows when at least one handler is passed
-          AND we have a phone (for call/whatsapp) or onMessage. The recipient
-          gets these unmasked once the donor accepts (parent decides). */}
-      {(onCall || onMessage || onWhatsApp || profile.phone) && (
+      {/* Contact pill row — hidden entirely when `interactive` is false
+          (request not active any more) so Call / WhatsApp / Chat close
+          together with the rest of the disclosure. Otherwise: shows when
+          at least one handler is passed AND we have a phone (for call/
+          whatsapp) or onMessage. The recipient gets these unmasked once
+          the donor accepts (parent decides). */}
+      {interactive && (onCall || onMessage || onWhatsApp || profile.phone) && (
         <View style={[styles.actions, { borderTopColor: theme.divider }]}>
           {(onCall || profile.phone) && (
             <Pressable

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -79,12 +79,18 @@ create table if not exists public.profiles (
   constraint profiles_longitude_range check (longitude is null or (longitude between -180 and 180)),
   constraint profiles_total_donations_nonneg check (total_donations >= 0),
 
-  -- ── Age gate: donors must be 18+ ────────────────────────────────────────
-  -- Recipients can be any age. 'both' implies donor capability, so 18+ required.
+  -- ── Age gate: donors must be 18-65 ──────────────────────────────────────
+  -- Recipients can be any age. 'both' implies donor capability, so the
+  -- 18-65 window applies. The upper bound matches WHO + most national
+  -- blood-bank guidelines for whole-blood donation. `date_of_birth > today
+  -- - 66 years` means "younger than 66", i.e. still 65 today.
   constraint profiles_donor_age check (
     role = 'recipient'
     or date_of_birth is null
-    or date_of_birth <= (current_date - interval '18 years')
+    or (
+          date_of_birth <= (current_date - interval '18 years')
+      and date_of_birth >  (current_date - interval '66 years')
+    )
   )
 );
 


### PR DESCRIPTION
… + onboarding/splash polish

Five tightly related fixes shipping together — all tighten the contact + eligibility surface and the onboarding flow.

1. No email anywhere as a contact channel
   - request/[id].tsx `callContact`: was `phone ?? email` piped into `tel:` (which Android sometimes routes to the default mail handler). Now phone-only; if no phone, toast "No phone shared — use chat".
   - donor/[id].tsx `handleCall`: was `donor.phone ? tel: : mailto:` fallback. Now phone-only with the same "no phone shared" alert.

2. Splash screen no longer crashes on auth state flips
   - app/_layout.tsx: `hideAsync()` was firing every time `loading` transitioned false (sign-out → re-auth, profile refresh, etc.). SDK 54's splash module unregisters itself on first hide, so the second call threw "No native splash screen registered for given view controller". Added a one-shot ref guard + `.catch(() => {})`.

3. Contact channels close together when a request seals
   - components/ProfileCard.tsx: new `interactive` prop (default true). When false, hides the Call / WhatsApp / Chat pills row entirely.
   - request/[id].tsx: passes `interactive={isActive}` to both ProfileCard call-sites (donor seeing recipient, recipient seeing accepted donors). Also gates the per-donor live-GPS pill + the aggregate "Track donor live" CTA on `isActive`.
   - donor/[id].tsx: new `commitmentActive` state resolved from the discovered mutual-commitment request's `status`; subscribed to realtime UPDATEs so it flips false instantly. Call + Message buttons get `disabled={!channelsOpen}` plus a "Channel closed" banner. Handlers also early-return with a kinder alert. Bonus: removed the ✉ emoji from the Message button (no-emoji rule), relabelled to "Call" / "Message".

4. DOB onboarding now shows for every role
   - app/onboarding.tsx step ordering: previously skipped 'dob' for recipients, but the identity-step CTA still read "Next · Date of birth" → recipients tapped Next and landed on Blood group, thinking the DOB screen was broken. Now: recipient flow is role · identity · dob · blood · contact · confirm. The DobStep component already adapts its copy ("Optional — helps us serve you better"). Recipients can leave DOB blank and continue; donor/both still must enter a valid date.

5. Donor age window is now 18-65 (was 18+)
   - app/onboarding.tsx: new `MAX_DONOR_AGE = 65` constant. Validator rejects donor/both above 65 with a kind downgrade prompt. DobStep eligibility pill distinguishes too-young vs. too-old. Soft- downgrade toast: "Donors must be 18–65".
   - app/profile/edit.tsx: same `MAX_DONOR_AGE`. Validator returns "Donors must be 65 or younger" on save.
   - backend/authController.js: silent downgrade fires for `age < 18 || age > 65`. Response message reads "Donor role requires age 18–65".
   - backend/profileController.js: PATCH /profiles/me rejects role flip to donor/both when stored age is outside the window.
   - supabase_schema.sql: profiles_donor_age CHECK tightened to require `date_of_birth > current_date - interval '66 years'` AND `<= current_date - interval '18 years'` for donor/both.
   - migrations/2026-05-14-donor-max-age.sql: delta with a guarded pre-flight — aborts loudly if any existing donor/both row is already older than 65 so the operator decides (downgrade or exception) before the constraint lands.

Validation:
  - `npx tsc --noEmit` clean.
  - Migration ends with a single-row PASS/FAIL diagnostic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated donor eligibility window to ages 18–65; users over 65 can register as recipients
  * Request status now gates contact and messaging availability; channels close when requests become inactive

* **Bug Fixes**
  * Fixed splash screen to display only once per app session

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aashir-athar/BludStack-RN/pull/6)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->